### PR TITLE
Make the filters work the same across all four job boards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 **/.money_cache.json
 **/storage_state.json
 .gd_profile/
+logs/
 
 # gitignore template for Jupyter Notebooks
 # website: http://jupyter.org/

--- a/README.md
+++ b/README.md
@@ -275,12 +275,16 @@ A normal run reads exactly as it always did. `-q` keeps warnings and failures an
 drops the progress; `-v` adds timestamps and says which module spoke.
 
 **Every run records itself.** Unless you pass `--no-log-file`, it writes
-`run_20260812-143502.log` in the current directory - named for when it started,
-so runs sort chronologically and two of them never collide. The file gets
-everything down to debug in full detail whatever the terminal is showing, which
-is the point: a scrape you left running is exactly the one whose output you no
-longer have. `--log-file` names it yourself, and a path whose directory does not
-exist is refused up front rather than halfway through the run.
+`logs/run_20260812-143502.log` - named for when the run started, so they sort
+chronologically and two never collide. The directory is created on the way, and
+is gitignored. The file gets everything down to debug in full detail whatever
+the terminal is showing, which is the point: a scrape you left running is
+exactly the one whose output you no longer have.
+
+They accumulate, one per run, which is why they are not loose in the working
+directory next to `job_listing.json`. Nothing prunes them - `rm -rf logs/` when
+you have had enough. `--log-file` puts one somewhere else, creating whatever
+directory you name.
 
 **The library logs, the commands print.** A message about work in progress -
 which board answered, how many survived, which one refused - goes through

--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ first one saw - which is why it is off unless asked for.
 So `-e 5` is a real filter on Naukri and, on the other three, a request nobody
 answered.
 
+**`--enrich` reads the postings themselves** when a search card cannot answer an
+`-e` filter. It fetches at most `--enrich-limit` postings (default 25), only ones
+that survived every other filter, and only from a board with a readable posting
+page - today that is LinkedIn, whose guest pages need no account and no browser.
+What it finds is recorded as `experience-enriched` with the phrase the posting
+used, so a number in the CSV can always be traced back. Experience only: a salary
+read out of free prose is as likely to be a relocation allowance as a wage.
+
 **Unverifiable jobs are kept and flagged, not dropped.** A flag ending `-unknown`
 means the posting did not say; one ending `-unpublished` means its board never
 says. So a LinkedIn result comes back `experience-unpublished` and a Naukri one

--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ Indeed's Indian site rather than its US one.
 `-n/--limit` is how many to pull from each board *before* filtering, so a tight
 filter returns fewer than you asked for - raise it if you want more survivors.
 
+`--want N` asks for the number you actually have in mind: each board is re-read
+with a doubled pull until N jobs survive the filter, it runs out, or
+`--max-rounds` (default 4) is reached. It costs requests - the boards page from
+the top and Google Jobs is a scrolling list, so a second round re-reads what the
+first one saw - which is why it is off unless asked for.
+
 **The boards differ in what they will tell you**, which decides what `-e` and
 `--min-salary` can actually do:
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,15 @@ LinkedIn forms are left open rather than answered with guesses.
 
 ### The CSV
 
+**One job on three boards is one application.** The same posting found on
+LinkedIn, Indeed and Google Jobs is stored three times - each board carries
+different fields, and only some carry a url - but applying collapses them to the
+copy you can actually act on: Easy Apply over a plain url, a url over a Google
+Jobs row that has none. The boards that lost are recorded on the survivor as
+`also-on-indeed` flags, and a later run will not apply again through another
+board. Two postings from the *same* board stay two postings; there its own id is
+the authority.
+
 `applied_jobs.csv` appends across runs and never records the same posting twice. It
 is written UTF-8 with a BOM and a stable column order, so **Google Sheets imports it
 cleanly** via *File > Import > Upload* (currency symbols survive). Columns:

--- a/README.md
+++ b/README.md
@@ -69,16 +69,39 @@ uv run applicant search "developer" -l India --title "senior python" \
 | `--salary-basis` | how to compare other currencies: `ppp`, `market` or `strict` |
 | `-e/--experience YEARS` | years you have; keeps jobs asking for that much |
 | `--posted-within DAYS` | how recently it was posted |
+| `--strict` / `--strict-published` | what to do with what could not be checked |
 
 Location and date are handed to the boards themselves where they support it
 (LinkedIn and Indeed both filter by date server side), and applied locally otherwise.
 `-n/--limit` is how many to pull from each board *before* filtering, so a tight
 filter returns fewer than you asked for - raise it if you want more survivors.
 
-**Unverifiable jobs are kept and flagged, not dropped.** Most postings state no
-salary, and only Naukri publishes required experience, so those come back marked
-`salary-unknown` / `experience-unknown` in the `flags` field. Pass `--strict` to drop
-anything that could not actually be checked.
+**The boards differ in what they will tell you**, which decides what `-e` and
+`--min-salary` can actually do:
+
+| | LinkedIn | Indeed | Naukri | Google Jobs |
+|---|---|---|---|---|
+| states required experience | no | no | **yes** | no |
+| states pay | no | yes | yes | sometimes |
+| filters by date itself | yes | yes | no | no |
+
+So `-e 5` is a real filter on Naukri and, on the other three, a request nobody
+answered.
+
+**Unverifiable jobs are kept and flagged, not dropped.** A flag ending `-unknown`
+means the posting did not say; one ending `-unpublished` means its board never
+says. So a LinkedIn result comes back `experience-unpublished` and a Naukri one
+that hid its range comes back `experience-unknown`.
+
+| | keeps | drops |
+|---|---|---|
+| *(default)* | everything, flagged | nothing |
+| `--strict-published` | boards that never publish the field | postings that could have said and did not |
+| `--strict` | only what was fully checked | both kinds of silence |
+
+`--strict` with `-e` therefore discards every LinkedIn, Indeed and Google Jobs
+result, since none of them publishes experience at all. `--strict-published` is
+usually the one you want: it tightens Naukri without deleting the other three.
 
 `--experience 5` keeps jobs whose stated range contains 5 years, so it excludes
 roles wanting 0-2 years as well as ones wanting 8+. `5+ years` is treated as having

--- a/README.md
+++ b/README.md
@@ -260,6 +260,31 @@ Google Jobs is the most fragile of the four: it is Google Search, its CSS classe
 obfuscated and rotate, and it gives no posting URL - applications route back to the
 originating board, which is reported as `via`.
 
+## How much it says
+
+Every subcommand takes `-v`, `-q` and `--log-file`:
+
+```
+uv run applicant search "python developer" -l India -q
+uv run applicant search "python developer" -l India -v
+uv run applicant search "python developer" -l India --log-file run.log
+```
+
+A normal run reads exactly as it always did. `-q` keeps warnings and failures and
+drops the progress; `-v` adds timestamps and says which module spoke; a
+`--log-file` gets everything down to debug in full detail whatever the terminal
+is showing, which is what you want from a scrape you left running.
+
+**The library logs, the commands print.** A message about work in progress -
+which board answered, how many survived, which one refused - goes through
+`applicant.log`, so `-q` silences it. The answer a subcommand was asked for -
+`status`' tally, `rates`' table, where a file was written - is printed, because
+silencing the answer is not what asking for quiet means.
+
+Importing `applicant` configures no logging at all, so embedding it in another
+program is silent until that program calls `applicant.log.configure()` or handles
+the `applicant` logger itself.
+
 ## Usage
 `uv run applicant -h` lists everything. `python -m applicant` works identically, and is
 what to use without `uv`.
@@ -284,6 +309,7 @@ src/applicant/
   browser.py     launching Playwright in a way the boards accept
   filters.py     JobFilter, and the flags saying what could not be checked
   places.py      whether a posting's location is inside the one you asked for
+  log.py         where the running commentary goes, and how much of it
   storage.py     job_listing.json and applied_jobs.csv
   search.py      the facade over boards, filters and storage
   boards/        one module per job board, all returning Job

--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ uv run applicant search "developer" -l India --title "senior python" \
 
 Location and date are handed to the boards themselves where they support it
 (LinkedIn and Indeed both filter by date server side), and applied locally otherwise.
+
+**A country filter understands its cities.** Boards answer `-l India` with bare
+city names, so `apply -l India` over a stored file checks "India" against
+"Bengaluru, Karnataka" itself and keeps it. A posting somewhere we can name is
+dropped; one we cannot place at all - "Remote", a town in no table - is kept and
+flagged `location-unverified`. The same table means `-l Bengaluru` reaches
+Indeed's Indian site rather than its US one.
 `-n/--limit` is how many to pull from each board *before* filtering, so a tight
 filter returns fewer than you asked for - raise it if you want more survivors.
 
@@ -241,6 +248,7 @@ src/applicant/
   salary.py      reading pay off a posting, normalised to an annual figure
   browser.py     launching Playwright in a way the boards accept
   filters.py     JobFilter, and the flags saying what could not be checked
+  places.py      whether a posting's location is inside the one you asked for
   storage.py     job_listing.json and applied_jobs.csv
   search.py      the facade over boards, filters and storage
   boards/        one module per job board, all returning Job

--- a/README.md
+++ b/README.md
@@ -262,18 +262,25 @@ originating board, which is reported as `via`.
 
 ## How much it says
 
-Every subcommand takes `-v`, `-q` and `--log-file`:
+Every subcommand takes `-v`, `-q`, `--log-file` and `--no-log-file`:
 
 ```
 uv run applicant search "python developer" -l India -q
 uv run applicant search "python developer" -l India -v
-uv run applicant search "python developer" -l India --log-file run.log
+uv run applicant search "python developer" -l India --log-file today.log
+uv run applicant search "python developer" -l India --no-log-file
 ```
 
 A normal run reads exactly as it always did. `-q` keeps warnings and failures and
-drops the progress; `-v` adds timestamps and says which module spoke; a
-`--log-file` gets everything down to debug in full detail whatever the terminal
-is showing, which is what you want from a scrape you left running.
+drops the progress; `-v` adds timestamps and says which module spoke.
+
+**Every run records itself.** Unless you pass `--no-log-file`, it writes
+`run_20260812-143502.log` in the current directory - named for when it started,
+so runs sort chronologically and two of them never collide. The file gets
+everything down to debug in full detail whatever the terminal is showing, which
+is the point: a scrape you left running is exactly the one whose output you no
+longer have. `--log-file` names it yourself, and a path whose directory does not
+exist is refused up front rather than halfway through the run.
 
 **The library logs, the commands print.** A message about work in progress -
 which board answered, how many survived, which one refused - goes through

--- a/README.md
+++ b/README.md
@@ -60,11 +60,23 @@ uv run applicant search "developer" -l India --title "senior python" \
     --company infosys --min-salary 1200000 --currency INR --posted-within 7
 ```
 
+**`--title` and `--company` may be repeated**, and a job needs to match only one
+of them. A search worth running usually spans more than one way of naming the
+same role:
+
+```
+uv run applicant search "AI ML engineer" -l India -e 3 \
+    -t ai -t ml -t "machine learning" -t "data scientist"
+```
+
+Each value keeps its own rule - every word of it must appear, in any order - so
+`-t "machine learning"` still means both words.
+
 | Flag | Filters on |
 |---|---|
 | `-l/--location` | where the job is |
-| `-t/--title` | words in the job title, any order |
-| `-c/--company` | the hiring company |
+| `-t/--title` | words in the job title, any order; repeat for any-of |
+| `-c/--company` | the hiring company; repeatable too |
 | `--min-salary` + `--currency` | annual pay floor |
 | `--salary-basis` | how to compare other currencies: `ppp`, `market` or `strict` |
 | `-e/--experience YEARS` | years you have; keeps jobs asking for that much |

--- a/docs/board-parity-plan.md
+++ b/docs/board-parity-plan.md
@@ -10,7 +10,20 @@ they will filter for us, and — more awkwardly — in what they will *tell* us.
 `JobFilter` is written as if they were uniform, and the gap between those two
 facts is where results are lost.
 
-**Status: proposed. Nothing here is built.**
+**Status: phases 0-3 implemented, with four changes made while building them.
+Phases 4-6 are not built.**
+
+| Change | Why |
+|---|---|
+| `--strict published` became a separate `--strict-published` flag | an optional argument to `--strict` is ambiguous against the `search` keywords positional: `search --strict "python developer"` would consume the keywords as the flag's value |
+| `-unstated` stayed `-unknown`; only `-unpublished` is new | renaming the existing flags would break the vocabulary the README documents and every `applied_jobs.csv` already written, for no new information |
+| `matches()` reads `publishes` off `job.source` rather than taking it as an argument | the posting knows which board produced it, so `apply` attributes silence correctly against a stored file with no plumbing at all |
+| Location matching became whole-word | a test caught the plain substring test putting "India" inside "Indianapolis, Indiana". Titles are unaffected and still match substrings |
+
+One thing §3.3 got wrong: the outbound country cannot be appended to the shared
+location string in `Jobs.search`, because Naukri slugs that string into its url
+and `/ai-jobs-in-bengaluru-india` is not a page. It is done inside Indeed's
+`host_for` instead, where the need actually is.
 
 ---
 
@@ -240,15 +253,15 @@ Six phases, each independently shippable, each with tests that do not touch the
 network. The shortlist in `tests/test_target_job_filters.py` is the acceptance
 test throughout: it should take fewer runs and fewer surprises at each phase.
 
-| Phase | Change | Test |
-|---|---|---|
-| 0 | `Capability` per board; `search.py` derives `skip`; `NATIVE_DATE` removed | existing suite stays green unchanged — that is the point |
-| 1 | `-unstated` / `-unpublished` flags; `--strict published` | a LinkedIn posting survives `--strict published -e 3`; a Naukri one that states nothing does not |
-| 2 | Location containment, `location-unverified`, country appended outbound | `apply -l India` keeps the eight; `host_for('Bengaluru')` reaches `in.indeed.com` |
-| 3 | Repeatable `-t` / `-c` | one invocation returns all eight and none of the decoys |
-| 4 | Cross-board fingerprint at apply time | the same job from three boards writes one worklist row, the actionable one |
-| 5 | `--want` / `--max-pages` | a stub board paged until N survivors, and stopping at the cap |
-| 6 | `--enrich` | fixture detail pages; a fetch failure leaves the flag, not a drop |
+| Phase | Change | Test | Built |
+|---|---|---|---|
+| 0 | `Capability` per board; `search.py` derives `skip`; `NATIVE_DATE` removed | existing suite stays green unchanged — that is the point | **yes** |
+| 1 | `-unpublished` flags; `--strict-published` | a LinkedIn posting survives `--strict-published -e 3`; a Naukri one that states nothing does not | **yes** |
+| 2 | Location containment, `location-unverified`, country resolved outbound | `apply -l India` keeps the eight; `host_for('Bengaluru')` reaches `in.indeed.com` | **yes** |
+| 3 | Repeatable `-t` / `-c` | one invocation returns all eight and none of the decoys | **yes** |
+| 4 | Cross-board fingerprint at apply time | the same job from three boards writes one worklist row, the actionable one | no |
+| 5 | `--want` / `--max-pages` | a stub board paged until N survivors, and stopping at the cap | no |
+| 6 | `--enrich` | fixture detail pages; a fetch failure leaves the flag, not a drop | no |
 
 **If only two land, make them 2 and 3.** They are what this shortlist needs, they
 are small, and neither depends on the refactor. Phase 0 and 1 are what make the

--- a/docs/board-parity-plan.md
+++ b/docs/board-parity-plan.md
@@ -173,19 +173,7 @@ A small place table — the project is already India-centric (Naukri, AmbitionBo
 a checked-in INR PPP factor) — mapping a country to its states and metros:
 
 ```python
-CONTAINS = {
-    'india': {
-        'karnataka',
-        'bengaluru',
-        'bangalore',
-        'telangana',
-        'hyderabad',
-        'maharashtra',
-        'pune',
-        'mumbai',
-        ...,
-    }
-}
+CONTAINS = {'india': {'karnataka', 'bengaluru', 'bangalore', 'telangana', 'hyderabad'}}
 ```
 
 Two uses, both of which pay for it:

--- a/docs/board-parity-plan.md
+++ b/docs/board-parity-plan.md
@@ -1,0 +1,276 @@
+# Filtering across the job boards
+
+Written against `claude/job-filter-testing-08074p` (`28cc6d2`), driven by what
+`tests/test_target_job_filters.py` found: a shortlist of eight AI/ML postings in
+Indian metros is reachable, but only by running the tool four times and knowing
+which flags quietly do nothing on which board.
+
+The four boards are not four ways of doing the same thing. They differ in what
+they will filter for us, and — more awkwardly — in what they will *tell* us.
+`JobFilter` is written as if they were uniform, and the gap between those two
+facts is where results are lost.
+
+**Status: proposed. Nothing here is built.**
+
+---
+
+## 1. What each board actually gives us
+
+Read off the four board modules, not off the README.
+
+| | LinkedIn | Indeed | Naukri | Google Jobs |
+|---|---|---|---|---|
+| How it is fetched | guest endpoint, no browser | JSON blob, browser on challenge | browser, API intercepted | browser, Search results read structurally |
+| Filters **location** itself | yes, `location=` | yes, `l=` **and the host** | yes, in the url slug | yes, `"… in <location>"` |
+| Filters **date** itself | yes, `f_TPR=r<secs>` | yes, `fromage=<days>` | no | no |
+| Publishes **experience** | no | no | **yes** | no |
+| Publishes **salary** | no | yes | yes | sometimes¹ |
+| Publishes **posting date** | yes, ISO | yes, epoch | yes, relative | sometimes¹ |
+| Publishes a **url** | yes | yes | yes | **no**² |
+| Publishes an **id** | yes | yes | yes | no, synthesised³ |
+
+1. `googlejobs.py:116-159` classifies a card's visible lines by regex. A salary
+   line is recognised when it carries a currency symbol or a period word; a date
+   line when it says "ago"/"today". Both are best-effort, not fields.
+2. `googlejobs.py:158` — Google gives no posting url; applications route back to
+   the originating board, reported as `via`.
+3. `googlejobs.py:144-147` — a SHA1 of title/company/location/via, so cards
+   dedupe against each other rather than collapsing into one.
+
+Two rows of that table carry the whole problem. **Experience is published by one
+board in four, and the url by three in four.** Everything below follows.
+
+---
+
+## 2. What that costs today
+
+Each of these is pinned by a test in `tests/test_target_job_filters.py`, so the
+plan below has a way to prove it changed something.
+
+### 2.1 `-e` is real on Naukri and decorative elsewhere
+
+The shortlist is defined by experience: one to five years. On Naukri that filter
+does exactly what it says. On the other three boards every posting comes back
+`experience-unknown` and is kept regardless, so `-e 3` neither includes nor
+excludes anything — the user believes they filtered and did not.
+
+`--strict` then makes it worse rather than better: it drops everything that could
+not be checked, which is *all* LinkedIn, Indeed and Google results. A flag whose
+documented job is "be more careful" silently deletes three of four sources.
+
+The `keep_unknown` decision (`filters.py:93-99`) cannot distinguish "this posting
+did not say" from "this board never says". It should.
+
+### 2.2 `--min-salary` is real on two and a half
+
+Same shape, less severe. LinkedIn guest cards carry no pay at all
+(`linkedin.py:134-143`), Google's is a heuristic. On a shortlist like this one —
+where no posting states pay — every result comes back `salary-unknown`, which is
+honest but means the filter is doing nothing.
+
+### 2.3 Location is a country at the board and a city in the file
+
+`Jobs.search` hands location to the board and skips the local re-check
+(`search.py:124`), because a country search legitimately answers with bare city
+names. That is correct, and it is why `search -l India` works.
+
+But the same string is checked *locally* by `apply` (`cli.py:133-139`), which has
+no board to delegate to. `apply -l India` compares "India" against
+"Bengaluru, Karnataka" and matches nothing at all: `0 of 12 stored jobs match`.
+The user's filter did not narrow their worklist, it emptied it.
+
+There is a second, quieter version of this on Indeed. `host_for`
+(`indeed.py:54-60`) picks the country site by looking for a country name *in the
+location string*, defaulting to the US. So `-l Bengaluru` — the string that works
+locally and on Naukri — sends Indeed to `indeed.com` and returns American jobs.
+The one spelling that satisfies the local filter is the one that breaks Indeed.
+
+### 2.4 One `--title` cannot express one shortlist
+
+`--title` is a single AND-of-words string (`filters.py:80-83`). These eight
+postings span "AI", "ML", "Machine Learning" and "Data Scientist", and no single
+value reaches more than six of them. Four runs into the same output file do work,
+because writes merge — but the user has to know that.
+
+### 2.5 `-n` is counted before filtering
+
+`-n 25` pulls 25 per board and *then* filters, so a filter tight enough to be
+useful returns a handful. The README says to raise the limit; nothing tells the
+user how far, and the answer differs per board because the boards differ in how
+much of the filter they applied themselves.
+
+### 2.6 The same job from three boards is three rows
+
+`_key` (`storage.py:44-53`) is `(source, id)`, and `ApplicationLog.existing_keys`
+(`storage.py:95-102`) is the same pair. A posting that appears on LinkedIn, Indeed
+and Google Jobs is three stored jobs and, at apply time, three rows in the
+worklist — the CSV's never-twice guarantee is per board, not per job. For Google
+Jobs specifically the row also has no url, so the worklist entry cannot be acted
+on without searching again.
+
+---
+
+## 3. The design
+
+One idea does most of the work: **boards should declare what they do and what
+they know, and the filter should read that declaration.** Everything else is a
+consequence.
+
+### 3.1 Boards declare capabilities
+
+Today `search.py:45` carries `NATIVE_DATE = ('linkedin', 'indeed')` — a fact
+about two board modules, written down in a third, by name. Adding a board means
+remembering to edit a tuple somewhere else.
+
+```python
+# boards/__init__.py
+@dataclass(frozen=True)
+class Capability:
+    # what the board applies server side, so a local re-check would be wrong
+    filters: frozenset[str] = frozenset()
+    # what its cards actually carry, so silence can be attributed correctly
+    publishes: frozenset[str] = frozenset()
+```
+
+| Board | `filters` | `publishes` |
+|---|---|---|
+| LinkedIn | location, posted | posted, url, id |
+| Indeed | location, posted | salary, posted, url, id, employment_type, remote |
+| Naukri | location | **experience**, salary, posted, url, id |
+| Google Jobs | location | salary, posted, employment_type, via |
+
+`Jobs.search` then derives its `skip` from `board.capability.filters` instead of
+hardcoding it, and `NATIVE_DATE` goes away. This is a pure refactor with no
+behaviour change, which makes it the safe thing to land first.
+
+### 3.2 Flags say *who* could not tell us
+
+`matches()` gains the board's `publishes` set and splits one flag into two:
+
+| Flag | Means |
+|---|---|
+| `experience-unstated` | the board publishes experience; this posting did not state it |
+| `experience-unpublished` | this board never publishes experience — nothing was checked, and nothing could have been |
+
+Same for `salary-*`. The distinction is not cosmetic: it is the difference
+between a posting being evasive and a source being silent, and only the first is
+a reason to drop anything.
+
+`--strict` gains an optional value, defaulting to today's meaning so existing
+invocations are untouched:
+
+```
+--strict            # as now: drop anything unverifiable
+--strict published  # drop only where the board could have told us and the posting did not
+```
+
+`--strict published -e 3` is then the flag a user actually wants: it tightens
+Naukri without deleting the other three boards.
+
+### 3.3 Location: containment, and a country for Indeed
+
+A small place table — the project is already India-centric (Naukri, AmbitionBox,
+a checked-in INR PPP factor) — mapping a country to its states and metros:
+
+```python
+CONTAINS = {'india': {'karnataka', 'bengaluru', 'bangalore', 'telangana',
+                      'hyderabad', 'maharashtra', 'pune', 'mumbai', ...}}
+```
+
+Two uses, both of which pay for it:
+
+- **Locally**, `_text_matches` on location becomes containment-aware, so
+  `apply -l India` keeps the Bengaluru postings instead of emptying the worklist.
+  Where the table cannot decide — a country we have no entry for, against a city
+  we do not recognise — the posting is **kept and flagged `location-unverified`**,
+  which is what the rest of this codebase does with things it cannot check, rather
+  than silently dropping a correct result.
+- **Outbound**, the country is appended when a board needs it, so `-l Bengaluru`
+  reaches Indeed as `Bengaluru, India` and `host_for` resolves `in.indeed.com`
+  instead of the US site.
+
+### 3.4 `-t` and `-c` become repeatable
+
+`action='append'`, matching **any** of the given values (each value keeping its
+current all-words-in-any-order rule):
+
+```
+uv run applicant search "AI ML engineer" -l India -e 3 \
+    -t ai -t ml -t "machine learning" -t "data scientist"
+```
+
+One run, all eight, no decoys. A single `-t` behaves exactly as it does today.
+
+This also blunts the substring overreach the tests pin down (`-t ai` matching
+"Graduate Trainee"), because the user no longer has to pick one short word to
+cover several title families.
+
+### 3.5 Ask for survivors, not for pulls
+
+`-n` keeps its meaning. A new `--want N` pages each board until N postings have
+*survived* the filter or `--max-pages` is reached, which is the number the user
+actually has in mind. Per board, so a board that answers a tight filter well is
+not held back by one that does not.
+
+### 3.6 One job, three boards, one application
+
+Add a cross-board fingerprint — normalised `(company, title, city)` — alongside
+the existing key. `job_listing.json` keeps every source's row, because throwing
+away a source's copy loses its url and its fields. `ApplicationLog` dedupes on
+the fingerprint as well as `(source, id)`, and when several rows describe the
+same job, applying picks the one that can actually be acted on: a LinkedIn Easy
+Apply row over a plain url, a url over Google's `via` with no link at all.
+
+### 3.7 Enrichment, opt-in and last
+
+The only real fix for §2.1 on three boards is to open the posting and read it.
+`--enrich` would fetch the detail page for postings that survived every other
+filter, parse experience and salary out of it with the existing helpers, and
+re-run the checks that were previously unverifiable.
+
+Deliberately last, and deliberately opt-in: it is N more requests against
+bot-guarded sites, on the slowest path, and it is the part most likely to break
+when a site is redesigned. Bounded by a count, off by default, and a failure to
+enrich must leave the posting flagged rather than dropped.
+
+---
+
+## 4. Sequencing
+
+Six phases, each independently shippable, each with tests that do not touch the
+network. The shortlist in `tests/test_target_job_filters.py` is the acceptance
+test throughout: it should take fewer runs and fewer surprises at each phase.
+
+| Phase | Change | Test |
+|---|---|---|
+| 0 | `Capability` per board; `search.py` derives `skip`; `NATIVE_DATE` removed | existing suite stays green unchanged — that is the point |
+| 1 | `-unstated` / `-unpublished` flags; `--strict published` | a LinkedIn posting survives `--strict published -e 3`; a Naukri one that states nothing does not |
+| 2 | Location containment, `location-unverified`, country appended outbound | `apply -l India` keeps the eight; `host_for('Bengaluru')` reaches `in.indeed.com` |
+| 3 | Repeatable `-t` / `-c` | one invocation returns all eight and none of the decoys |
+| 4 | Cross-board fingerprint at apply time | the same job from three boards writes one worklist row, the actionable one |
+| 5 | `--want` / `--max-pages` | a stub board paged until N survivors, and stopping at the cap |
+| 6 | `--enrich` | fixture detail pages; a fetch failure leaves the flag, not a drop |
+
+**If only two land, make them 2 and 3.** They are what this shortlist needs, they
+are small, and neither depends on the refactor. Phase 0 and 1 are what make the
+other four honest — without the capability declaration, every later phase has to
+re-guess which board knows what.
+
+A README correction belongs with phase 1: the filter table documents `-e` and
+`--min-salary` without saying that three of four boards publish neither, which is
+the single most misleading thing a new user meets.
+
+---
+
+## 5. What this does not do
+
+- **No new boards.** Parity across the four that exist, not a fifth.
+- **No change to `applicant jobs`.** The signed-in LinkedIn scrape takes no filter
+  flags today and does not gain any here.
+- **No move off the flat files.** The status store is `docs/ci-plan.md` §3.5's
+  subject and stays there; §3.6 above is a dedupe key, not a schema.
+- **No scoring or ranking.** Filters keep answering yes or no. "Which of these
+  eight is the best job" is a different feature, and the reviews clients are
+  already the beginning of it.
+- **Nothing that guesses.** The existing rule holds throughout: what cannot be
+  checked is kept and flagged, never invented and never quietly dropped.

--- a/docs/board-parity-plan.md
+++ b/docs/board-parity-plan.md
@@ -10,8 +10,8 @@ they will filter for us, and — more awkwardly — in what they will *tell* us.
 `JobFilter` is written as if they were uniform, and the gap between those two
 facts is where results are lost.
 
-**Status: phases 0-3 implemented, with four changes made while building them.
-Phases 4-6 are not built.**
+**Status: all six phases implemented, with seven changes made while building
+them.**
 
 | Change | Why |
 |---|---|
@@ -19,11 +19,19 @@ Phases 4-6 are not built.**
 | `-unstated` stayed `-unknown`; only `-unpublished` is new | renaming the existing flags would break the vocabulary the README documents and every `applied_jobs.csv` already written, for no new information |
 | `matches()` reads `publishes` off `job.source` rather than taking it as an argument | the posting knows which board produced it, so `apply` attributes silence correctly against a stored file with no plumbing at all |
 | Location matching became whole-word | a test caught the plain substring test putting "India" inside "Indianapolis, Indiana". Titles are unaffected and still match substrings |
+| Cross-board dedupe fires only across *different* boards | the first version collapsed two ids on one board, and the storage tests caught it. There the board's own id is the authority, and overruling it discards a job somebody really did advertise twice |
+| §3.5's paging re-reads instead of resuming | there is no offset to resume from — LinkedIn and Indeed page from the top, Naukri counts pages, and Google Jobs is a scrolling list. So `--want` doubles the pull and re-reads, which is why rounds are capped and one round is still the default |
+| §3.7 enriches experience only, not salary | `parse_salary` over free prose would read a relocation allowance or a bonus cap as a wage. Nothing in this project guesses, so `--min-salary` keeps saying honestly that it could not check |
 
 One thing §3.3 got wrong: the outbound country cannot be appended to the shared
 location string in `Jobs.search`, because Naukri slugs that string into its url
 and `/ai-jobs-in-bengaluru-india` is not a page. It is done inside Indeed's
 `host_for` instead, where the need actually is.
+
+§3.7 also assumed enrichment would work board by board. Only LinkedIn has a
+posting page reachable without a browser — Indeed's and Naukri's are behind the
+same bot checks their searches are, and Google Jobs has no url at all — so
+`describe()` exists there and boards without one are simply not read.
 
 ---
 
@@ -259,9 +267,9 @@ test throughout: it should take fewer runs and fewer surprises at each phase.
 | 1 | `-unpublished` flags; `--strict-published` | a LinkedIn posting survives `--strict-published -e 3`; a Naukri one that states nothing does not | **yes** |
 | 2 | Location containment, `location-unverified`, country resolved outbound | `apply -l India` keeps the eight; `host_for('Bengaluru')` reaches `in.indeed.com` | **yes** |
 | 3 | Repeatable `-t` / `-c` | one invocation returns all eight and none of the decoys | **yes** |
-| 4 | Cross-board fingerprint at apply time | the same job from three boards writes one worklist row, the actionable one | no |
-| 5 | `--want` / `--max-pages` | a stub board paged until N survivors, and stopping at the cap | no |
-| 6 | `--enrich` | fixture detail pages; a fetch failure leaves the flag, not a drop | no |
+| 4 | Cross-board fingerprint at apply time | the same job from three boards writes one worklist row, the actionable one | **yes** |
+| 5 | `--want` / `--max-rounds` | a stub board re-read until N survivors, and stopping at the cap | **yes** |
+| 6 | `--enrich` | a stub posting page; a refusal leaves the flag, not a drop | **yes** |
 
 **If only two land, make them 2 and 3.** They are what this shortlist needs, they
 are small, and neither depends on the refactor. Phase 0 and 1 are what make the

--- a/docs/board-parity-plan.md
+++ b/docs/board-parity-plan.md
@@ -173,8 +173,19 @@ A small place table — the project is already India-centric (Naukri, AmbitionBo
 a checked-in INR PPP factor) — mapping a country to its states and metros:
 
 ```python
-CONTAINS = {'india': {'karnataka', 'bengaluru', 'bangalore', 'telangana',
-                      'hyderabad', 'maharashtra', 'pune', 'mumbai', ...}}
+CONTAINS = {
+    'india': {
+        'karnataka',
+        'bengaluru',
+        'bangalore',
+        'telangana',
+        'hyderabad',
+        'maharashtra',
+        'pune',
+        'mumbai',
+        ...,
+    }
+}
 ```
 
 Two uses, both of which pay for it:

--- a/src/applicant/boards/__init__.py
+++ b/src/applicant/boards/__init__.py
@@ -1,7 +1,70 @@
 """One module per job board, each returning `applicant.models.Job`.
 
 Clients are imported lazily by `applicant.search.Jobs` so that a board needing a
-browser costs nothing until it is actually used.
+browser costs nothing until it is actually used. What each board can *do*, on the
+other hand, is needed before one is chosen - by the facade, to know which filters
+it may skip, and by `applicant.filters`, to know whose silence a missing field is.
+So capabilities live here as plain data, importable without pulling in httpx or
+Playwright.
 """
 
 from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class Capability:
+    """What a board does for us, and what it tells us.
+
+    `filters` names the checks the board applies server side. Re-checking those
+    locally is not merely wasted work, it is wrong: a country search answers with
+    bare city names, so a second pass over `job.location` throws away every
+    correct result.
+
+    `publishes` names the fields its cards actually carry. A board that never
+    publishes experience is not the same as a posting that declined to state it,
+    and only the second is a reason to drop anything.
+    """
+
+    filters: frozenset[str] = field(default_factory=frozenset)
+    publishes: frozenset[str] = field(default_factory=frozenset)
+
+
+# Read off the board modules, not off the README:
+#
+# - LinkedIn's guest card carries a title, company, location and date, and
+#   nothing about pay or experience (linkedin.py:124-143).
+# - Indeed's job card JSON adds a salary snippet, job type and a remote marker,
+#   but says nothing about experience either (indeed.py:163-181).
+# - Naukri is the only one that publishes required experience (naukri.py:110-136).
+# - Google Jobs is Search: pay and date are classified out of a card's visible
+#   text when they appear at all, and there is no posting url (googlejobs.py:116-159).
+CAPABILITIES = {
+    'linkedin': Capability(
+        filters=frozenset({'location', 'posted'}),
+        publishes=frozenset({'posted', 'url', 'id'}),
+    ),
+    'indeed': Capability(
+        filters=frozenset({'location', 'posted'}),
+        publishes=frozenset({'salary', 'posted', 'url', 'id', 'employment_type', 'remote'}),
+    ),
+    'naukri': Capability(
+        filters=frozenset({'location'}),
+        publishes=frozenset({'experience', 'salary', 'posted', 'url', 'id'}),
+    ),
+    'googlejobs': Capability(
+        filters=frozenset({'location'}),
+        publishes=frozenset({'salary', 'posted', 'employment_type', 'via'}),
+    ),
+}
+
+# A source we do not know is assumed to publish everything, so a missing field
+# reads as the posting's silence rather than the board's - which is how every
+# filter behaved before capabilities existed.
+UNKNOWN = Capability(publishes=frozenset({'experience', 'salary', 'posted'}))
+
+
+def capability(source: str | None) -> Capability:
+    """What the named board does. Unknown sources get the permissive default."""
+    return CAPABILITIES.get(source or '', UNKNOWN)

--- a/src/applicant/boards/googlejobs.py
+++ b/src/applicant/boards/googlejobs.py
@@ -18,6 +18,7 @@ from urllib.parse import urlencode
 from ..browser import browser, looks_blocked
 from ..dates import relative_to_iso
 from ..models import BlockedError, Job
+from . import CAPABILITIES
 
 BASE = 'https://www.google.com/search'
 CARD = 'div[jsname="y1Aese"][role="button"]'
@@ -35,6 +36,8 @@ SALARY = re.compile(
 
 
 class GoogleJobs:
+    capability = CAPABILITIES['googlejobs']
+
     def __init__(self, headless=True, timeout=45000, hl='en'):
         self.headless = headless
         self.timeout = timeout

--- a/src/applicant/boards/indeed.py
+++ b/src/applicant/boards/indeed.py
@@ -18,6 +18,7 @@ import httpx
 from ..browser import USER_AGENT, browser, looks_blocked
 from ..dates import epoch_to_iso
 from ..models import BlockedError, Job
+from . import CAPABILITIES
 
 BASE = 'https://www.indeed.com'
 PAGE_SIZE = 10  # what Indeed advances `start` by, even though a page holds more
@@ -73,6 +74,8 @@ MOSAIC = re.compile(
 
 
 class Indeed:
+    capability = CAPABILITIES['indeed']
+
     def __init__(self, domain=None, delay=1.0, timeout=30.0, headless=True, client=None):
         # None means "work it out from the search location"
         self.domain = domain.rstrip('/') if domain else None

--- a/src/applicant/boards/indeed.py
+++ b/src/applicant/boards/indeed.py
@@ -18,6 +18,7 @@ import httpx
 from ..browser import USER_AGENT, browser, looks_blocked
 from ..dates import epoch_to_iso
 from ..models import BlockedError, Job
+from ..places import country_for
 from . import CAPABILITIES
 
 BASE = 'https://www.indeed.com'
@@ -53,12 +54,20 @@ COUNTRY_HOSTS = {
 
 
 def host_for(location):
-    """'Bengaluru, India' -> 'https://in.indeed.com'. Defaults to the US site."""
+    """'Bengaluru, India' -> 'https://in.indeed.com'. Defaults to the US site.
+
+    A bare city name is resolved through `applicant.places` rather than falling
+    through to the US site: '-l Bengaluru' is the spelling that satisfies every
+    other board, and answering it with American jobs is the worst of the
+    possible outcomes.
+    """
     text = (location or '').strip().lower()
     for country, code in COUNTRY_HOSTS.items():
         if re.search(r'\b{}\b'.format(re.escape(country)), text):
             return 'https://{}.indeed.com'.format(code)
-    return BASE
+
+    code = COUNTRY_HOSTS.get(country_for(text) or '')
+    return 'https://{}.indeed.com'.format(code) if code else BASE
 
 
 HEADERS = {

--- a/src/applicant/boards/linkedin.py
+++ b/src/applicant/boards/linkedin.py
@@ -26,6 +26,7 @@ from urllib.parse import urlencode
 import httpx
 
 from ..browser import BROWSER_ARGS, USER_AGENT
+from ..log import get
 from ..models import BlockedError, Job, JobsError
 from . import CAPABILITIES
 
@@ -38,6 +39,8 @@ GUEST_POSTING = 'https://www.linkedin.com/jobs-guest/jobs/api/jobPosting/{}'
 GUEST_PAGE_SIZE = 10
 
 HEADERS = {'User-Agent': USER_AGENT, 'Accept-Language': 'en-US,en;q=0.9'}
+
+logger = get(__name__)
 
 CARD = re.compile(r'<li>(.*?)</li>', re.DOTALL)
 FIELDS = {
@@ -211,7 +214,7 @@ class LinkedIn:
     ):
         target = Path(filepath)
         if target.exists() and not overwrite:
-            print(
+            logger.warning(
                 '{} already exists. Pass overwrite to log in again, or use '
                 'restore_session() to reuse it.'.format(filepath)
             )
@@ -238,20 +241,20 @@ class LinkedIn:
             )
 
         context.storage_state(path=str(target))
-        print('session saved to {}'.format(target))
+        logger.info('session saved to {}'.format(target))
 
     def restore_session(self, filepath: str | Path = 'cookies.json'):
         state = self._load_state(filepath)
         if state is None:
-            print('no usable session in {}; call login() first'.format(filepath))
+            logger.warning('no usable session in {}; call login() first'.format(filepath))
             return False
 
         page = self._start(storage_state=state)
         page.goto('https://www.linkedin.com/feed/', wait_until='domcontentloaded')
         if '/login' in page.url or '/authwall' in page.url:
-            print('saved session is no longer valid; call login() again')
+            logger.warning('saved session is no longer valid; call login() again')
             return False
-        print('session restored from {}'.format(filepath))
+        logger.info('session restored from {}'.format(filepath))
         return True
 
     def _load_state(self, filepath: str | Path):
@@ -285,7 +288,7 @@ class LinkedIn:
                     'sameSite': 'Lax',
                 }
             )
-        print('converted {} Selenium cookies to a Playwright session'.format(len(converted)))
+        logger.info('converted {} Selenium cookies to a Playwright session'.format(len(converted)))
         return {'cookies': converted, 'origins': []}
 
     # -- logged in flows --------------------------------------------------
@@ -341,7 +344,7 @@ class LinkedIn:
             )
 
         total = save_jobs(jobs, filepath)
-        print('scraped {} recommended jobs ({} in {})'.format(len(jobs), total, filepath))
+        logger.info('scraped {} recommended jobs ({} in {})'.format(len(jobs), total, filepath))
         return jobs
 
     def easy_apply(self, filepath='job_listing.json'):
@@ -355,7 +358,7 @@ class LinkedIn:
             with open(filepath, encoding='utf-8') as file:
                 stored = json.load(file).get('list', [])
         except (FileNotFoundError, ValueError) as error:
-            print('could not read {}: {}'.format(filepath, error))
+            logger.warning('could not read {}: {}'.format(filepath, error))
             return []
 
         applied = []
@@ -381,11 +384,11 @@ class LinkedIn:
                 submit.click()
                 page.wait_for_timeout(1500)
                 applied.append(item['url'])
-                print('applied: {}'.format(item.get('title') or item['url']))
+                logger.info('applied: {}'.format(item.get('title') or item['url']))
             else:
                 # multi step form - close it and leave this one alone
                 page.keyboard.press('Escape')
-                print('skipped (multi step): {}'.format(item.get('title') or item['url']))
+                logger.info('skipped (multi step): {}'.format(item.get('title') or item['url']))
 
         return applied
 

--- a/src/applicant/boards/linkedin.py
+++ b/src/applicant/boards/linkedin.py
@@ -18,6 +18,7 @@ import json
 import re
 import time
 from contextlib import suppress
+from html import unescape
 from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import urlencode
@@ -33,6 +34,7 @@ if TYPE_CHECKING:
     from playwright.sync_api import BrowserContext, Page, Playwright
 
 GUEST_SEARCH = 'https://www.linkedin.com/jobs-guest/jobs/api/seeMoreJobPostings/search'
+GUEST_POSTING = 'https://www.linkedin.com/jobs-guest/jobs/api/jobPosting/{}'
 GUEST_PAGE_SIZE = 10
 
 HEADERS = {'User-Agent': USER_AGENT, 'Accept-Language': 'en-US,en;q=0.9'}
@@ -144,6 +146,26 @@ class LinkedIn:
             posted=found['posted'],
             easy_apply=None,  # the guest card does not say
         )
+
+    def describe(self, job: Job) -> str | None:
+        """The posting's own text, for what its search card never said.
+
+        The same guest surface `search` uses, so this needs no account and no
+        browser. Returns None when there is nothing to read - no id, or a page
+        that is not there - and raises on a rate limit, because carrying on
+        through one is how a working scrape becomes a blocked one.
+        """
+        if not job.id:
+            return None
+
+        response = self.client.get(GUEST_POSTING.format(job.id))
+        if response.status_code == 429:
+            raise BlockedError('LinkedIn rate limited the guest posting reads; slow down or retry')
+        if response.status_code != 200:
+            return None
+
+        text = unescape(TAGS.sub(' ', response.text))
+        return re.sub(r'\s+', ' ', text).strip() or None
 
     # -- browser session --------------------------------------------------
 

--- a/src/applicant/boards/linkedin.py
+++ b/src/applicant/boards/linkedin.py
@@ -26,6 +26,7 @@ import httpx
 
 from ..browser import BROWSER_ARGS, USER_AGENT
 from ..models import BlockedError, Job, JobsError
+from . import CAPABILITIES
 
 if TYPE_CHECKING:
     from playwright.sync_api import Browser as PlaywrightBrowser
@@ -55,6 +56,8 @@ def _clean(value):
 
 
 class LinkedIn:
+    capability = CAPABILITIES['linkedin']
+
     def __init__(
         self,
         path=None,

--- a/src/applicant/boards/naukri.py
+++ b/src/applicant/boards/naukri.py
@@ -16,6 +16,7 @@ import re
 from ..browser import browser, looks_blocked
 from ..dates import relative_to_iso
 from ..models import BlockedError, Job
+from . import CAPABILITIES
 
 BASE = 'https://www.naukri.com'
 API = re.compile(r'/jobapi/v\d+/search')
@@ -35,6 +36,8 @@ def search_url(keywords, location='', page=1):
 
 
 class Naukri:
+    capability = CAPABILITIES['naukri']
+
     def __init__(self, headless=True, timeout=45000, delay=1.5):
         self.headless = headless
         self.timeout = timeout

--- a/src/applicant/cli.py
+++ b/src/applicant/cli.py
@@ -12,7 +12,7 @@ import json
 import sys
 from pathlib import Path
 
-from .log import QUIET, configure, get
+from .log import QUIET, configure, default_file, get
 from .search import SOURCES
 
 logger = get(__name__)
@@ -267,7 +267,13 @@ def _add_logging(command) -> None:
     command.add_argument(
         '--log-file',
         metavar='PATH',
-        help='also write everything, in full detail, to this file',
+        help='write everything, in full detail, to this file. Defaults to a '
+        'run_<timestamp>.log in the current directory',
+    )
+    command.add_argument(
+        '--no-log-file',
+        action='store_true',
+        help='do not write a log file for this run',
     )
 
 
@@ -535,15 +541,18 @@ def main(argv: list[str] | None = None) -> int:
         parser.print_help()
         return 1
 
+    # a run records itself unless told not to; the file is only created once
+    # there is something to put in it
+    filepath = None if args.no_log_file else (args.log_file or default_file())
     try:
-        configure(
-            verbosity=QUIET if args.quiet else args.verbose,
-            filepath=args.log_file,
-        )
+        configure(verbosity=QUIET if args.quiet else args.verbose, filepath=filepath)
     except OSError as error:
         # a log file we cannot open is a mistake in the invocation, not a
         # reason to run the scrape and lose the record of it
-        print('could not open {}: {}'.format(args.log_file, error))
+        print('could not open {}: {}'.format(filepath, error))
         return 2
+
+    if filepath:
+        logger.info('logging this run to {}'.format(filepath))
 
     return handler(args) or 0

--- a/src/applicant/cli.py
+++ b/src/applicant/cli.py
@@ -112,7 +112,13 @@ def run_search(args) -> int:
 
     wanted = ALL if 'all' in args.source else args.source
     board = Jobs(sources=wanted, headless=not args.show)
-    found = board.search(args.keywords, _filters(args), limit=args.limit)
+    found = board.search(
+        args.keywords,
+        _filters(args),
+        limit=args.limit,
+        want=args.want,
+        max_rounds=args.max_rounds,
+    )
 
     if not found:
         print('nothing matched')
@@ -345,6 +351,21 @@ def build_parser() -> argparse.ArgumentParser:
     )
     search.add_argument(
         '-n', '--limit', type=int, default=25, help='jobs to pull per board, before filtering'
+    )
+    search.add_argument(
+        '--want',
+        type=int,
+        metavar='N',
+        help='keep reading each board until this many jobs survive the filter, '
+        'rather than filtering a fixed pull of --limit',
+    )
+    search.add_argument(
+        '--max-rounds',
+        type=int,
+        default=4,
+        metavar='N',
+        help='how many times --want may re-read a board, each round doubling the '
+        'pull and re-reading what it already saw (default 4)',
     )
     search.add_argument(
         '-o', '--output', default='job_listing.json', help='file path to store the scraped jobs'

--- a/src/applicant/cli.py
+++ b/src/applicant/cli.py
@@ -267,8 +267,8 @@ def _add_logging(command) -> None:
     command.add_argument(
         '--log-file',
         metavar='PATH',
-        help='write everything, in full detail, to this file. Defaults to a '
-        'run_<timestamp>.log in the current directory',
+        help='write everything, in full detail, to this file. Defaults to '
+        'logs/run_<timestamp>.log, and any directory named is created',
     )
     command.add_argument(
         '--no-log-file',

--- a/src/applicant/cli.py
+++ b/src/applicant/cli.py
@@ -118,6 +118,8 @@ def run_search(args) -> int:
         limit=args.limit,
         want=args.want,
         max_rounds=args.max_rounds,
+        enrich=args.enrich,
+        enrich_limit=args.enrich_limit,
     )
 
     if not found:
@@ -372,6 +374,20 @@ def build_parser() -> argparse.ArgumentParser:
     )
     search.add_argument(
         '--show', action='store_true', help='run the browser visibly, to solve a bot check yourself'
+    )
+    search.add_argument(
+        '--enrich',
+        action='store_true',
+        help='read the postings themselves to answer an --experience filter their '
+        'search cards could not. Slow, and only where a board offers a readable '
+        'posting page - currently LinkedIn',
+    )
+    search.add_argument(
+        '--enrich-limit',
+        type=int,
+        default=25,
+        metavar='N',
+        help='how many postings --enrich may read in one run (default 25)',
     )
     _add_filters(search)
     search.set_defaults(handler=run_search)

--- a/src/applicant/cli.py
+++ b/src/applicant/cli.py
@@ -239,8 +239,19 @@ def run_rates(args) -> int:
 
 
 def _add_filters(command) -> None:
-    command.add_argument('-t', '--title', help='keep jobs whose title contains these words')
-    command.add_argument('-c', '--company', help='keep jobs from companies matching this')
+    command.add_argument(
+        '-t',
+        '--title',
+        action='append',
+        help='keep jobs whose title contains these words. Repeat it to accept '
+        'any of several: -t ai -t ml -t "machine learning"',
+    )
+    command.add_argument(
+        '-c',
+        '--company',
+        action='append',
+        help='keep jobs from companies matching this. Repeatable, like --title',
+    )
     command.add_argument('--min-salary', type=float, help='annual salary floor, in --currency')
     command.add_argument('--currency', help='currency for --min-salary, e.g. INR or USD')
     command.add_argument(

--- a/src/applicant/cli.py
+++ b/src/applicant/cli.py
@@ -99,7 +99,9 @@ def _filters(args):
         salary_basis=args.salary_basis,
         experience=args.experience,
         posted_within_days=args.posted_within,
-        keep_unknown=not args.strict,
+        keep_unknown=not (args.strict or args.strict_published),
+        # --strict is the stricter of the two, so it wins when both are given
+        keep_unpublished=args.strict_published and not args.strict,
     )
 
 
@@ -261,8 +263,16 @@ def _add_filters(command) -> None:
     command.add_argument(
         '--strict',
         action='store_true',
-        help='drop jobs whose salary or date could not be read '
-        '(they are kept and flagged by default)',
+        help='drop jobs whose salary, experience or date could not be read '
+        '(they are kept and flagged by default). Note that this drops every '
+        'board that does not publish the field at all',
+    )
+    command.add_argument(
+        '--strict-published',
+        action='store_true',
+        help='drop a job only when its board does publish the field and the '
+        'posting stayed silent, keeping boards that never publish it - which '
+        'for --experience is every board but Naukri',
     )
 
 

--- a/src/applicant/cli.py
+++ b/src/applicant/cli.py
@@ -12,7 +12,10 @@ import json
 import sys
 from pathlib import Path
 
+from .log import QUIET, configure, get
 from .search import SOURCES
+
+logger = get(__name__)
 
 REVIEW_SOURCES = ('ambitionbox', 'glassdoor')
 
@@ -21,7 +24,7 @@ def run_jobs(args) -> int:
     from .boards.linkedin import LinkedIn
 
     if args.driver != 'chromedriver':
-        print(
+        logger.warning(
             'note: --driver is ignored now that LinkedIn runs on Playwright, '
             'which manages its own browser'
         )
@@ -64,7 +67,7 @@ def run_reviews(args) -> int:
             rating = client.fetch(args.company, max_reviews=args.max_reviews)
         except ReviewsError as error:
             # one blocked source should not throw away the other one's results
-            print('{}: {}'.format(source, error))
+            logger.warning('{}: {}'.format(source, error))
             continue
 
         print(
@@ -246,6 +249,28 @@ def run_rates(args) -> int:
     return 0
 
 
+def _add_logging(command) -> None:
+    """On every subcommand rather than before them.
+
+    A global flag would have to come first - `applicant -v search ...` - and
+    `normalise` reads a leading flag as the old bare-flag invocation of `jobs`,
+    so it would be rewritten into nonsense.
+    """
+    command.add_argument(
+        '-v',
+        '--verbose',
+        action='count',
+        default=0,
+        help='say more about what each board is doing, with timestamps',
+    )
+    command.add_argument('-q', '--quiet', action='store_true', help='only warnings and failures')
+    command.add_argument(
+        '--log-file',
+        metavar='PATH',
+        help='also write everything, in full detail, to this file',
+    )
+
+
 def _add_filters(command) -> None:
     command.add_argument(
         '-t',
@@ -338,6 +363,7 @@ def build_parser() -> argparse.ArgumentParser:
         action='store_false',
         help='Whether to display the browser or not (headless mode)',
     )
+    _add_logging(jobs)
     jobs.set_defaults(handler=run_jobs)
 
     search = commands.add_parser('search', help='search job boards without signing in')
@@ -390,6 +416,7 @@ def build_parser() -> argparse.ArgumentParser:
         help='how many postings --enrich may read in one run (default 25)',
     )
     _add_filters(search)
+    _add_logging(search)
     search.set_defaults(handler=run_search)
 
     apply_ = commands.add_parser(
@@ -407,6 +434,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     apply_.add_argument('--show', action='store_true', help='run the browser visibly')
     _add_filters(apply_)
+    _add_logging(apply_)
     apply_.set_defaults(handler=run_apply)
 
     reviews = commands.add_parser('reviews', help='fetch company ratings and pros/cons')
@@ -447,6 +475,7 @@ def build_parser() -> argparse.ArgumentParser:
         action='store_false',
         help='Whether to display the browser or not (headless mode)',
     )
+    _add_logging(reviews)
     reviews.set_defaults(handler=run_reviews)
 
     rates = commands.add_parser(
@@ -467,6 +496,7 @@ def build_parser() -> argparse.ArgumentParser:
         metavar='CODE',
         help='limit the refresh to these currencies, e.g. GBP SEK NZD',
     )
+    _add_logging(rates)
     rates.set_defaults(handler=run_rates)
 
     status = commands.add_parser('status', help='summarise stored jobs and applications')
@@ -477,6 +507,7 @@ def build_parser() -> argparse.ArgumentParser:
         '--log', default='applied_jobs.csv', help='CSV the applications were appended to'
     )
     status.add_argument('--json', help='also write the summary to this file as JSON')
+    _add_logging(status)
     status.set_defaults(handler=run_status)
 
     return parser
@@ -503,4 +534,16 @@ def main(argv: list[str] | None = None) -> int:
     if handler is None:
         parser.print_help()
         return 1
+
+    try:
+        configure(
+            verbosity=QUIET if args.quiet else args.verbose,
+            filepath=args.log_file,
+        )
+    except OSError as error:
+        # a log file we cannot open is a mistake in the invocation, not a
+        # reason to run the scrape and lose the record of it
+        print('could not open {}: {}'.format(args.log_file, error))
+        return 2
+
     return handler(args) or 0

--- a/src/applicant/filters.py
+++ b/src/applicant/filters.py
@@ -8,6 +8,7 @@ from datetime import date, datetime, timezone
 from .boards import capability
 from .models import Job
 from .money import Rates, convert
+from .places import within
 from .salary import parse_salary
 
 
@@ -52,15 +53,18 @@ class JobFilter:
         """
         flags: list[str] = []
 
-        for value, field_name in (
-            (self.title, 'title'),
-            (self.company, 'company'),
-            (self.location, 'location'),
-        ):
+        for value, field_name in ((self.title, 'title'), (self.company, 'company')):
             if not value or field_name in skip:
                 continue
             actual = getattr(job, field_name) or ''
             if not self._text_matches(value, actual):
+                return False, flags
+
+        if self.location and 'location' not in skip:
+            keep, flag = self._location_ok(job, self.location)
+            if flag:
+                flags.append(flag)
+            if not keep:
                 return False, flags
 
         if self.min_salary is not None and 'salary' not in skip:
@@ -90,6 +94,18 @@ class JobFilter:
         """Every word of the filter must appear, in any order."""
         actual = actual.lower()
         return all(word in actual for word in wanted.lower().split())
+
+    def _location_ok(self, job: Job, wanted: str) -> tuple[bool, str | None]:
+        """Text first, then containment: 'India' has to accept 'Bengaluru'.
+
+        Only the boards spell a country out; `apply` reads a stored file where
+        the location is whatever the board said, so without this a country
+        filter empties the worklist instead of narrowing it.
+        """
+        verdict = within(wanted, job.location)
+        if verdict is None:
+            return self.keep_unknown, 'location-unverified'
+        return verdict, None
 
     def _unverifiable(self, job: Job, field: str, stem: str) -> tuple[bool, str]:
         """What becomes of a posting that could not be checked, and what to call it.

--- a/src/applicant/filters.py
+++ b/src/applicant/filters.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
 
@@ -12,12 +13,27 @@ from .places import within
 from .salary import parse_salary
 
 
+def _values(wanted: str | Sequence[str] | None) -> list[str]:
+    """One filter or several, as a list. Empty means "does not constrain"."""
+    if wanted is None:
+        return []
+    if isinstance(wanted, str):
+        wanted = [wanted]
+    return [value for value in wanted if value and value.strip()]
+
+
 @dataclass
 class JobFilter:
-    """Every field is optional; unset fields simply do not constrain anything."""
+    """Every field is optional; unset fields simply do not constrain anything.
 
-    title: str | None = None
-    company: str | None = None
+    `title` and `company` take one value or several. Several match when *any* of
+    them does, because a shortlist worth having spans more title families than
+    one string of words can express - "AI", "ML", "Machine Learning" and "Data
+    Scientist" are one search to a person and four to a text match.
+    """
+
+    title: str | Sequence[str] | None = None
+    company: str | Sequence[str] | None = None
     location: str | None = None
     min_salary: float | None = None  # annual, in `currency`
     currency: str | None = None
@@ -54,10 +70,11 @@ class JobFilter:
         flags: list[str] = []
 
         for value, field_name in ((self.title, 'title'), (self.company, 'company')):
-            if not value or field_name in skip:
+            wanted = _values(value)
+            if not wanted or field_name in skip:
                 continue
             actual = getattr(job, field_name) or ''
-            if not self._text_matches(value, actual):
+            if not any(self._text_matches(one, actual) for one in wanted):
                 return False, flags
 
         if self.location and 'location' not in skip:
@@ -91,7 +108,12 @@ class JobFilter:
         return True, flags
 
     def _text_matches(self, wanted: str, actual: str) -> bool:
-        """Every word of the filter must appear, in any order."""
+        """Every word of one filter must appear, in any order.
+
+        Substring matching, deliberately: "ml" should find "AI/ML". The cost is
+        that a two letter filter overreaches - "ai" is inside "Trainee" - which
+        is why several narrow filters beat one short one.
+        """
         actual = actual.lower()
         return all(word in actual for word in wanted.lower().split())
 

--- a/src/applicant/filters.py
+++ b/src/applicant/filters.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
 
+from .boards import capability
 from .models import Job
 from .money import Rates, convert
 from .salary import parse_salary
@@ -30,6 +31,10 @@ class JobFilter:
     experience: float | None = None  # years you have
     posted_within_days: int | None = None
     keep_unknown: bool = True  # unverifiable jobs survive, flagged
+    # only consulted when keep_unknown is False. A board that never publishes a
+    # field is not the same as a posting that declined to state it: set this to
+    # drop the second and keep the first, rather than deleting whole boards.
+    keep_unpublished: bool = False
 
     def matches(
         self, job: Job, today: date | None = None, skip: tuple[str, ...] | list[str] = ()
@@ -40,6 +45,10 @@ class JobFilter:
         locally is not merely wasted work, it is wrong: boards answer a country
         search with bare city names ("Bengaluru"), so a second pass over
         `job.location` would throw away every correct result.
+
+        A flag ending `-unknown` means the posting did not say; one ending
+        `-unpublished` means its board never says, which `job.source` decides
+        through `applicant.boards.capability`.
         """
         flags: list[str] = []
 
@@ -82,6 +91,20 @@ class JobFilter:
         actual = actual.lower()
         return all(word in actual for word in wanted.lower().split())
 
+    def _unverifiable(self, job: Job, field: str, stem: str) -> tuple[bool, str]:
+        """What becomes of a posting that could not be checked, and what to call it.
+
+        Silence has two very different sources. A posting on a board that
+        publishes experience and states none is being evasive; a posting on a
+        board that never publishes it at all has said nothing wrong. Only the
+        first is a reason to drop anything, which is why `--strict` alone -
+        drop everything unverifiable - deletes three of the four boards the
+        moment an experience filter is set.
+        """
+        if field not in capability(job.source).publishes:
+            return self.keep_unknown or self.keep_unpublished, '{}-unpublished'.format(stem)
+        return self.keep_unknown, '{}-unknown'.format(stem)
+
     def _experience_ok(self, job: Job, years: float) -> tuple[bool, str | None]:
         """You qualify when your years fall inside the range the job asks for.
 
@@ -91,7 +114,7 @@ class JobFilter:
         """
         low, high = job.experience_min, job.experience_max
         if low is None and high is None:
-            return self.keep_unknown, 'experience-unknown'
+            return self._unverifiable(job, 'experience', 'experience')
         if low is not None and years < low:
             return False, None
         if high is not None and years > high:
@@ -101,11 +124,11 @@ class JobFilter:
     def _salary_ok(self, job: Job, minimum: float) -> tuple[bool, str | None]:
         salary = parse_salary(job.salary)
         if salary is None:
-            return self.keep_unknown, 'salary-unknown'
+            return self._unverifiable(job, 'salary', 'salary')
 
         top = salary.annual_high
         if top is None:
-            return self.keep_unknown, 'salary-unknown'
+            return self._unverifiable(job, 'salary', 'salary')
 
         flag = None
         if self.currency and salary.currency and salary.currency != self.currency:
@@ -127,10 +150,12 @@ class JobFilter:
         self, job: Job, within_days: int, today: date | None = None
     ) -> tuple[bool, str | None]:
         if not job.posted:
-            return self.keep_unknown, 'date-unknown'
+            return self._unverifiable(job, 'posted', 'date')
         try:
             posted = datetime.strptime(job.posted[:10], '%Y-%m-%d').date()
         except ValueError:
+            # the board published a date and we could not read it, which is a
+            # parse failure of ours, not a board that stays silent
             return self.keep_unknown, 'date-unknown'
         today = today or datetime.now(timezone.utc).date()
         return (today - posted).days <= within_days, None

--- a/src/applicant/log.py
+++ b/src/applicant/log.py
@@ -21,7 +21,9 @@ wants the commentary.
 from __future__ import annotations
 
 import logging
+import os
 import sys
+from datetime import datetime
 from typing import TextIO
 
 ROOT = 'applicant'
@@ -34,7 +36,18 @@ DETAILED = logging.Formatter('%(asctime)s %(levelname)-7s %(name)s: %(message)s'
 
 QUIET, NORMAL = -1, 0
 
+# One file per run, named for when the run started, in the directory the command
+# was invoked from - beside job_listing.json and applied_jobs.csv, which is
+# where this tool already keeps what it produces.
+FILENAME = 'run_{}.log'
+STAMP = '%Y%m%d-%H%M%S'
+
 logging.getLogger(ROOT).addHandler(logging.NullHandler())
+
+
+def default_file(now: datetime | None = None) -> str:
+    """`run_20260812-143502.log`. Local time, like the timestamps inside it."""
+    return FILENAME.format((now or datetime.now()).strftime(STAMP))
 
 
 def get(name: str) -> logging.Logger:
@@ -86,7 +99,16 @@ def configure(
     logger.addHandler(console)
 
     if filepath:
-        record = logging.FileHandler(filepath, encoding='utf-8')
+        # delay defers opening until the first record, so the directory is
+        # checked here instead - a mistyped path should fail now, while it can
+        # still be corrected, rather than halfway through a scrape
+        folder = os.path.dirname(os.path.abspath(filepath))
+        if not os.path.isdir(folder):
+            raise FileNotFoundError('no directory {} to write {} into'.format(folder, filepath))
+
+        # delay=True so a command that says nothing leaves no file behind: with
+        # a file written on every run, an empty one is just litter
+        record = logging.FileHandler(filepath, encoding='utf-8', delay=True)
         record.setLevel(logging.DEBUG)
         record.setFormatter(DETAILED)
         logger.addHandler(record)

--- a/src/applicant/log.py
+++ b/src/applicant/log.py
@@ -1,0 +1,109 @@
+"""Where the tool's running commentary goes.
+
+A scrape talks while it works - which board answered, how many postings
+survived, which one refused - and until now it said all of it with `print`.
+That is fine for one run in a terminal and no use at all for the two things
+people actually do with a long scrape: turn the noise down, or keep a record of
+what happened while they were not watching.
+
+So the library logs and the commands print. A message *about* the work in
+progress goes to a logger here; the answer a subcommand was asked for -
+`status`' tally, `rates`' table, where a file was written - stays a `print`,
+because that is the command's output rather than its commentary, and silencing
+it with `--quiet` would be silencing the answer.
+
+Nothing is configured on import. `applicant` carries a NullHandler, so importing
+any of this from another program is silent until that program asks otherwise;
+`configure()` is called by `main()` and by anyone embedding the library who
+wants the commentary.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from typing import TextIO
+
+ROOT = 'applicant'
+
+# INFO is the running commentary and reads as it always did, so a normal run
+# looks the same as it did when these were print calls. -v adds where each line
+# came from and when, which is what you want when a board starts misbehaving.
+PLAIN = logging.Formatter('%(message)s')
+DETAILED = logging.Formatter('%(asctime)s %(levelname)-7s %(name)s: %(message)s', '%H:%M:%S')
+
+QUIET, NORMAL = -1, 0
+
+logging.getLogger(ROOT).addHandler(logging.NullHandler())
+
+
+def get(name: str) -> logging.Logger:
+    """The logger for a module: `get(__name__)` inside the package."""
+    if name == ROOT or name.startswith(ROOT + '.'):
+        return logging.getLogger(name)
+    return logging.getLogger('{}.{}'.format(ROOT, name))
+
+
+def level_for(verbosity: int) -> int:
+    """-1 and below is quiet, 0 is the usual commentary, 1 and up is everything."""
+    if verbosity <= QUIET:
+        return logging.WARNING
+    return logging.INFO if verbosity == NORMAL else logging.DEBUG
+
+
+def configure(
+    verbosity: int = NORMAL,
+    stream: TextIO | None = None,
+    filepath: str | None = None,
+) -> logging.Logger:
+    """Send the library's commentary somewhere, and say how much of it.
+
+    Idempotent: calling it again replaces the handlers it added rather than
+    doubling every line, which matters because a test suite calls `main()`
+    dozens of times in one process.
+
+    A log file always gets the detailed format and everything down to DEBUG,
+    whatever the console is showing - the point of a file is to hold what you
+    did not know you would want.
+    """
+    logger = logging.getLogger(ROOT)
+    level = level_for(verbosity)
+    logger.setLevel(logging.DEBUG if filepath else level)
+    # Only once we are handling the output ourselves. Until `configure` is
+    # called these records propagate normally, so a program that embeds the
+    # library and configures its own root logger sees them; after it, they do
+    # not, so a program that does both is not shown every line twice.
+    logger.propagate = False
+
+    for handler in list(logger.handlers):
+        if not isinstance(handler, logging.NullHandler):
+            logger.removeHandler(handler)
+            handler.close()
+
+    console = logging.StreamHandler(stream if stream is not None else sys.stdout)
+    console.setLevel(level)
+    console.setFormatter(DETAILED if level <= logging.DEBUG else PLAIN)
+    logger.addHandler(console)
+
+    if filepath:
+        record = logging.FileHandler(filepath, encoding='utf-8')
+        record.setLevel(logging.DEBUG)
+        record.setFormatter(DETAILED)
+        logger.addHandler(record)
+
+    return logger
+
+
+def silence() -> None:
+    """Undo `configure`, all of it: back to what a freshly imported library is.
+
+    Including propagation, or a caller who configured us once could never hand
+    the records back to their own logging again.
+    """
+    logger = logging.getLogger(ROOT)
+    for handler in list(logger.handlers):
+        if not isinstance(handler, logging.NullHandler):
+            logger.removeHandler(handler)
+            handler.close()
+    logger.setLevel(logging.NOTSET)
+    logger.propagate = True

--- a/src/applicant/log.py
+++ b/src/applicant/log.py
@@ -36,18 +36,25 @@ DETAILED = logging.Formatter('%(asctime)s %(levelname)-7s %(name)s: %(message)s'
 
 QUIET, NORMAL = -1, 0
 
-# One file per run, named for when the run started, in the directory the command
-# was invoked from - beside job_listing.json and applied_jobs.csv, which is
-# where this tool already keeps what it produces.
+# One file per run, named for when the run started. In a directory of their own
+# rather than beside job_listing.json and applied_jobs.csv, because those two are
+# one stable file each and these accumulate - a working directory that gains a
+# file every time you run anything is one nobody keeps working in.
+FOLDER = 'logs'
 FILENAME = 'run_{}.log'
 STAMP = '%Y%m%d-%H%M%S'
 
 logging.getLogger(ROOT).addHandler(logging.NullHandler())
 
 
-def default_file(now: datetime | None = None) -> str:
-    """`run_20260812-143502.log`. Local time, like the timestamps inside it."""
-    return FILENAME.format((now or datetime.now()).strftime(STAMP))
+def default_file(now: datetime | None = None, folder: str = FOLDER) -> str:
+    """`logs/run_20260812-143502.log`.
+
+    Local time, matching the timestamps inside the file rather than the UTC the
+    application log records - one feature, one clock. Seconds are enough to keep
+    two runs apart; nobody starts two of these in the same second.
+    """
+    return os.path.join(folder, FILENAME.format((now or datetime.now()).strftime(STAMP)))
 
 
 def get(name: str) -> logging.Logger:
@@ -99,12 +106,12 @@ def configure(
     logger.addHandler(console)
 
     if filepath:
-        # delay defers opening until the first record, so the directory is
-        # checked here instead - a mistyped path should fail now, while it can
-        # still be corrected, rather than halfway through a scrape
-        folder = os.path.dirname(os.path.abspath(filepath))
-        if not os.path.isdir(folder):
-            raise FileNotFoundError('no directory {} to write {} into'.format(folder, filepath))
+        # The directory is made here rather than left to the handler: `delay`
+        # defers opening the file until the first record, and a path that cannot
+        # be written should fail now, while it can still be corrected, rather
+        # than halfway through a scrape. Making it also means `logs/` exists
+        # without anyone having to create it first.
+        os.makedirs(os.path.dirname(os.path.abspath(filepath)), exist_ok=True)
 
         # delay=True so a command that says nothing leaves no file behind: with
         # a file written on every run, an empty one is just litter

--- a/src/applicant/models.py
+++ b/src/applicant/models.py
@@ -62,6 +62,28 @@ def parse_experience(text: str | None) -> tuple[float | None, float | None]:
     return float(exact), float(exact)
 
 
+def experience_from(text: str | None) -> tuple[str, float | None, float | None] | None:
+    """What a free text description says about required experience.
+
+    -> (the phrase it used, low, high), or None when it says nothing usable.
+    The phrase comes back so a posting can record where its numbers came from
+    rather than storing a whole job description in `experience_text`.
+    """
+    if not text:
+        return None
+    match = FRESHER.search(text) or EXPERIENCE.search(text)
+    if match is None:
+        return None
+
+    phrase = match.group(0).strip()
+    low, high = parse_experience(phrase)
+    if low is None and high is None:
+        return None
+    if not _in_range(low) or not _in_range(high):
+        return None
+    return phrase, low, high
+
+
 class Job(BaseModel):
     """A posting, normalised across every board."""
 

--- a/src/applicant/places.py
+++ b/src/applicant/places.py
@@ -1,0 +1,348 @@
+"""Whether a posting's location is inside the one you asked for.
+
+Boards answer a country search with bare city names - "Bengaluru", not
+"Bengaluru, India" - which is fine while the board is doing the filtering and
+useless the moment we have to check it ourselves, as `applicant apply` does
+against a stored file. A plain text match of "India" against "Bengaluru,
+Karnataka" is false, so the filter that should have narrowed a worklist emptied
+it instead.
+
+So: a table of what is inside India, and the country names that say a posting is
+somewhere else. India because that is where this tool is pointed - Naukri,
+AmbitionBox and a checked-in INR conversion factor - and because a table nobody
+maintains is worse than an honest "cannot tell".
+
+Which is the third answer here. `within()` returns None when the question cannot
+be settled from what we know, and the caller keeps the posting and flags it,
+rather than dropping a result that may well be correct.
+"""
+
+from __future__ import annotations
+
+import re
+
+# States, union territories and the cities that actually appear in postings.
+# Both spellings wherever a city was renamed, since boards use either.
+INDIA = {
+    # states and union territories
+    'andhra pradesh',
+    'arunachal pradesh',
+    'assam',
+    'bihar',
+    'chhattisgarh',
+    'goa',
+    'gujarat',
+    'haryana',
+    'himachal pradesh',
+    'jharkhand',
+    'karnataka',
+    'kerala',
+    'madhya pradesh',
+    'maharashtra',
+    'manipur',
+    'meghalaya',
+    'mizoram',
+    'nagaland',
+    'odisha',
+    'orissa',
+    'punjab',
+    'rajasthan',
+    'sikkim',
+    'tamil nadu',
+    'telangana',
+    'tripura',
+    'uttar pradesh',
+    'uttarakhand',
+    'west bengal',
+    'delhi',
+    'jammu',
+    'kashmir',
+    'ladakh',
+    'puducherry',
+    'pondicherry',
+    'chandigarh',
+    'andaman',
+    'nicobar',
+    'lakshadweep',
+    'daman',
+    'diu',
+    # cities
+    'bengaluru',
+    'bangalore',
+    'hyderabad',
+    'secunderabad',
+    'pune',
+    'pimpri',
+    'chinchwad',
+    'mumbai',
+    'bombay',
+    'navi mumbai',
+    'thane',
+    'chennai',
+    'madras',
+    'kolkata',
+    'calcutta',
+    'new delhi',
+    'noida',
+    'greater noida',
+    'gurugram',
+    'gurgaon',
+    'ghaziabad',
+    'faridabad',
+    'ahmedabad',
+    'gandhinagar',
+    'surat',
+    'vadodara',
+    'rajkot',
+    'jaipur',
+    'jodhpur',
+    'udaipur',
+    'kota',
+    'indore',
+    'bhopal',
+    'nagpur',
+    'nashik',
+    'aurangabad',
+    'kolhapur',
+    'solapur',
+    'coimbatore',
+    'madurai',
+    'tiruchirappalli',
+    'trichy',
+    'salem',
+    'tirupur',
+    'kochi',
+    'cochin',
+    'ernakulam',
+    'thiruvananthapuram',
+    'trivandrum',
+    'kozhikode',
+    'calicut',
+    'thrissur',
+    'mysuru',
+    'mysore',
+    'mangaluru',
+    'mangalore',
+    'hubli',
+    'dharwad',
+    'belagavi',
+    'belgaum',
+    'lucknow',
+    'kanpur',
+    'varanasi',
+    'agra',
+    'meerut',
+    'prayagraj',
+    'allahabad',
+    'gorakhpur',
+    'visakhapatnam',
+    'vizag',
+    'vijayawada',
+    'guntur',
+    'nellore',
+    'tirupati',
+    'warangal',
+    'bhubaneswar',
+    'cuttack',
+    'patna',
+    'ranchi',
+    'jamshedpur',
+    'raipur',
+    'guwahati',
+    'dehradun',
+    'shimla',
+    'srinagar',
+    'amritsar',
+    'ludhiana',
+    'jalandhar',
+    'mohali',
+    'panchkula',
+    'karnal',
+    'panipat',
+    'rohtak',
+    'hisar',
+    'siliguri',
+    'howrah',
+    'durgapur',
+    'bhavnagar',
+    'jamnagar',
+    'bareilly',
+    'aligarh',
+    'moradabad',
+    'jhansi',
+    'sangli',
+    'satara',
+}
+
+WITHIN = {'india': INDIA}
+
+# Which country each known place belongs to.
+COUNTRY_OF_PLACE = {place: country for country, places in WITHIN.items() for place in places}
+
+# Enough country names to recognise that a posting is somewhere *else*. Ambiguous
+# ones are left out on purpose: Georgia is a country and a US state, and Jersey
+# is an island and a city, so neither can settle anything on its own.
+COUNTRIES = {
+    'india',
+    'united states',
+    'usa',
+    'us',
+    'america',
+    'canada',
+    'mexico',
+    'brazil',
+    'argentina',
+    'chile',
+    'colombia',
+    'peru',
+    'united kingdom',
+    'uk',
+    'england',
+    'scotland',
+    'wales',
+    'northern ireland',
+    'ireland',
+    'france',
+    'germany',
+    'spain',
+    'portugal',
+    'italy',
+    'netherlands',
+    'belgium',
+    'luxembourg',
+    'switzerland',
+    'austria',
+    'denmark',
+    'norway',
+    'sweden',
+    'finland',
+    'iceland',
+    'poland',
+    'czechia',
+    'czech republic',
+    'slovakia',
+    'hungary',
+    'romania',
+    'bulgaria',
+    'greece',
+    'croatia',
+    'serbia',
+    'estonia',
+    'latvia',
+    'lithuania',
+    'ukraine',
+    'russia',
+    'turkey',
+    'israel',
+    'united arab emirates',
+    'uae',
+    'saudi arabia',
+    'qatar',
+    'kuwait',
+    'bahrain',
+    'oman',
+    'egypt',
+    'morocco',
+    'south africa',
+    'kenya',
+    'nigeria',
+    'ghana',
+    'ethiopia',
+    'china',
+    'hong kong',
+    'taiwan',
+    'japan',
+    'south korea',
+    'north korea',
+    'singapore',
+    'malaysia',
+    'indonesia',
+    'thailand',
+    'vietnam',
+    'philippines',
+    'cambodia',
+    'australia',
+    'new zealand',
+    'sri lanka',
+    'bangladesh',
+    'pakistan',
+    'nepal',
+    'bhutan',
+    'maldives',
+    'myanmar',
+    'afghanistan',
+    'iran',
+    'iraq',
+    'jordan',
+    'lebanon',
+}
+
+
+def _pattern(names) -> re.Pattern[str]:
+    """One alternation, longest first so 'new delhi' wins over 'delhi'."""
+    ordered = sorted(names, key=len, reverse=True)
+    return re.compile(r'\b(?:{})\b'.format('|'.join(re.escape(name) for name in ordered)))
+
+
+# word boundaries throughout, so 'India' never matches 'Indiana'
+PLACES = _pattern(COUNTRY_OF_PLACE)
+NATIONS = _pattern(COUNTRIES)
+
+
+def names(target: str, text: str) -> bool:
+    """Does `text` use every word of `target`, in any order, as a whole word?
+
+    Whole words matter here in a way they do not for a job title: "India" is
+    inside "Indianapolis, Indiana", and a location filter that answers an Indian
+    search with Indiana is worse than one that answers nothing.
+    """
+    return all(
+        re.search(r'\b{}\b'.format(re.escape(word)), text) is not None for word in target.split()
+    )
+
+
+def countries_in(location: str | None) -> set[str]:
+    """Every country `location` names, directly or through a place we know."""
+    text = (location or '').lower()
+    found = set(NATIONS.findall(text))
+    found.update(COUNTRY_OF_PLACE[place] for place in PLACES.findall(text))
+    return found
+
+
+def country_for(location: str | None) -> str | None:
+    """The country a location is in, when exactly one is implied.
+
+    'Bengaluru' -> 'india'. Used to reach the right country site on a board that
+    picks its host from the search string, so a bare city name does not quietly
+    return jobs from the other side of the world.
+    """
+    found = countries_in(location)
+    return found.pop() if len(found) == 1 else None
+
+
+def within(wanted: str, actual: str | None) -> bool | None:
+    """Is `actual` inside `wanted`? None when what we know cannot settle it.
+
+    Text matching first, so a city or a state filter behaves exactly as it always
+    has. Only a country filter consults the table, because only a country filter
+    is routinely asked about a location that never spells it out.
+    """
+    target = (wanted or '').strip().lower()
+    text = (actual or '').strip().lower()
+    if not target:
+        return True
+    if not text:
+        return False  # a posting with no location cannot be shown to be in one
+    if names(target, text):
+        return True
+
+    if target not in COUNTRIES:
+        # a city or state filter, already answered by the text match above
+        return False
+
+    implied = countries_in(text)
+    if target in implied:
+        return True
+    if implied:
+        return False  # somewhere we can name, and it is not where you asked
+    return None  # a place we have never heard of: say so rather than guess

--- a/src/applicant/reviews/glassdoor.py
+++ b/src/applicant/reviews/glassdoor.py
@@ -4,8 +4,11 @@ import json
 import re
 from contextlib import suppress
 
+from ..log import get
 from .errors import ChallengeError, ParseError, ReviewsError
 from .models import CompanyRating, Review
+
+logger = get(__name__)
 
 BASE = 'https://www.glassdoor.com'
 PAGE_SIZE = 10
@@ -155,7 +158,7 @@ class GlassdoorClient:
         try:
             context.storage_state(path='storage_state.json')
         except Exception as error:  # noqa: BLE001 - reported, never fatal to the scrape
-            print('could not write storage_state.json: {}'.format(error))
+            logger.warning('could not write storage_state.json: {}'.format(error))
 
     # -- parsing ----------------------------------------------------------
 

--- a/src/applicant/search.py
+++ b/src/applicant/search.py
@@ -15,11 +15,12 @@ no matter which board they came from.
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Protocol
 
 from .boards import Capability
 from .filters import JobFilter
-from .models import Job, JobsError
+from .models import Job, JobsError, experience_from
 from .storage import ApplicationLog, fingerprint, save_jobs
 
 if TYPE_CHECKING:
@@ -43,6 +44,20 @@ class Board(Protocol):
 
 
 SOURCES = ('linkedin', 'indeed', 'naukri', 'googlejobs')
+
+
+@dataclass
+class _Enrichment:
+    """Reading postings themselves, and the requests that costs.
+
+    `described` is keyed by posting so a board re-read under `want` does not pay
+    for the same page twice; `budget` counts only pages actually fetched.
+    """
+
+    budget: int
+    described: dict[tuple[str | None, str | None], str | None] = field(default_factory=dict)
+    stopped: bool = False
+
 
 # where jobs handed to _easy_apply are staged for the LinkedIn client to read back
 EASY_APPLY_LISTING = 'applied_via_jobs_interface.json'
@@ -94,6 +109,8 @@ class Jobs:
         limit: int = 25,
         want: int | None = None,
         max_rounds: int = 4,
+        enrich: bool = False,
+        enrich_limit: int = 25,
         on_error: Callable[[str, Exception], None] | None = None,
     ) -> list[Job]:
         """Search every configured board and return the filtered, merged results.
@@ -103,15 +120,19 @@ class Jobs:
         with a larger limit until that many get through, the board runs out, or
         `max_rounds` is reached. Left as None nothing changes and each board is
         read exactly once.
+
+        `enrich` reads the postings themselves for an experience filter the
+        search cards could not answer, at most `enrich_limit` of them.
         """
         filters = filters or JobFilter()
         collected: list[Job] = []
+        plan = _Enrichment(budget=enrich_limit) if enrich else None
 
         for name in self.sources:
             client = self._client(name)
             try:
                 kept, seen = self._from_board(
-                    client, name, keywords, filters, limit, want, max_rounds
+                    client, name, keywords, filters, limit, want, max_rounds, plan
                 )
             except JobsError as error:
                 (on_error or self._report)(name, error)
@@ -135,6 +156,7 @@ class Jobs:
         limit: int,
         want: int | None,
         max_rounds: int,
+        plan: _Enrichment | None = None,
     ) -> tuple[list[Job], int]:
         """One board's surviving jobs, and how many were read to get them.
 
@@ -150,6 +172,16 @@ class Jobs:
         # see Capability.filters for why a second pass would be wrong
         skip = sorted(native)
         posted = filters.posted_within_days if 'posted' in native else None
+
+        # when the postings themselves can answer the experience filter, hold it
+        # back until they have been read - a card's silence is not an answer
+        deferred = (
+            plan is not None
+            and filters.experience is not None
+            and callable(getattr(client, 'describe', None))
+        )
+        if deferred:
+            skip = [*skip, 'experience']
 
         pull = limit
         kept: list[Job] = []
@@ -169,6 +201,10 @@ class Jobs:
                 job.flags = flags
                 kept.append(job)
 
+            if deferred and plan is not None:
+                self._enrich(client, kept, plan)
+                kept = self._recheck_experience(kept, filters)
+
             if want is None or len(kept) >= want:
                 break
             if seen < pull:
@@ -179,6 +215,59 @@ class Jobs:
                 print('{}: {} of {} match, reading {}'.format(name, len(kept), seen, pull))
 
         return (kept[:want] if want else kept), seen
+
+    def _enrich(self, client: Board, jobs: list[Job], plan: _Enrichment) -> None:
+        """Read the posting itself where its card never stated the experience.
+
+        Only what a filter actually needs, only for jobs that survived every
+        other check, and only up to a budget: this is the slowest path in the
+        project and the one most likely to be noticed by a site that would
+        rather we were not here. Experience only - a salary read out of free
+        prose is as likely to be a relocation allowance as a wage, and nothing
+        in this project is ever guessed.
+        """
+        describe = getattr(client, 'describe')  # noqa: B009 - presence is the check
+
+        for job in jobs:
+            if job.experience_min is not None or job.experience_max is not None:
+                continue
+
+            key = (job.source, job.id)
+            if key not in plan.described:
+                if plan.stopped or plan.budget <= 0:
+                    continue
+                try:
+                    plan.described[key] = describe(job)
+                except JobsError as error:
+                    # one refusal means the next request is worse than useless
+                    print('{}: {} (enrichment stopped)'.format(job.source, error))
+                    plan.stopped = True
+                    continue
+                plan.budget -= 1
+
+            found = experience_from(plan.described.get(key))
+            if found is None:
+                continue
+
+            phrase, low, high = found
+            job.experience_text = phrase
+            job.experience_min, job.experience_max = low, high
+            job.flags = [*job.flags, 'experience-enriched']
+
+    def _recheck_experience(self, jobs: list[Job], filters: JobFilter) -> list[Job]:
+        """The check held back for enrichment, now that the postings have been read."""
+        check = JobFilter(
+            experience=filters.experience,
+            keep_unknown=filters.keep_unknown,
+            keep_unpublished=filters.keep_unpublished,
+        )
+        kept = []
+        for job in jobs:
+            keep, flags = check.matches(job)
+            if keep:
+                job.flags = [*job.flags, *flags]
+                kept.append(job)
+        return kept
 
     def _report(self, name: str, error: Exception) -> None:
         print('{}: {}'.format(name, error))

--- a/src/applicant/search.py
+++ b/src/applicant/search.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Protocol
 from .boards import Capability
 from .filters import JobFilter
 from .models import Job, JobsError
-from .storage import ApplicationLog, save_jobs
+from .storage import ApplicationLog, fingerprint, save_jobs
 
 if TYPE_CHECKING:
     from .boards.linkedin import LinkedIn
@@ -163,6 +163,7 @@ class Jobs:
                     kept.append(job)
             jobs = kept
 
+        jobs = self._one_per_job(jobs)
         entries: list[tuple[Job, str, str]] = []
         linkedin_targets = []
 
@@ -188,6 +189,60 @@ class Jobs:
             '{} new rows in {} ({} already recorded)'.format(written, log, len(entries) - written)
         )
         return entries
+
+    def _reach(self, job: Job) -> int:
+        """How far this copy of a posting gets you, highest first.
+
+        Easy Apply can be automated; a url can at least be opened; a Google Jobs
+        row has neither and leaves you searching for it again by hand.
+        """
+        if job.source == 'linkedin' and job.url and job.easy_apply is not False:
+            return 2
+        return 1 if job.url else 0
+
+    def _one_per_job(self, jobs: Iterable[Job]) -> list[Job]:
+        """Collapse the same posting from several boards into the usable copy.
+
+        Boards are searched independently, so a job advertised on three of them
+        arrives three times - and applying to each is three approaches to one
+        employer. The copies that lose are recorded on the survivor as
+        `also-on-<board>` flags, so nothing disappears silently.
+
+        Only across boards. Two postings from one board are two postings, however
+        alike they look: there the board's own id is the authority, and second
+        guessing it would throw away a job somebody really did advertise twice.
+        """
+        best: dict[str, Job] = {}
+        ordered: list[Job] = []
+
+        for job in jobs:
+            mark = fingerprint(job.to_dict())
+            rival = best.get(mark or '')
+            if mark is None or rival is None or rival.source == job.source:
+                # nothing to collapse against: not enough to be sure it is the
+                # same job, the first copy of it, or the same board again
+                if mark is not None and rival is None:
+                    best[mark] = job
+                ordered.append(job)
+                continue
+
+            winner, loser = (job, rival) if self._reach(job) > self._reach(rival) else (rival, job)
+            if winner is not rival:
+                ordered[ordered.index(rival)] = winner
+                best[mark] = winner
+            # the loser may itself have outlived an earlier copy, so carry its
+            # record of them across rather than losing it with the object
+            winner.flags = self._merge_flags(winner, loser)
+
+        return ordered
+
+    def _merge_flags(self, winner: Job, loser: Job) -> list[str]:
+        elsewhere = dict.fromkeys(
+            flag for flag in (*winner.flags, *loser.flags) if flag.startswith('also-on-')
+        )
+        elsewhere['also-on-{}'.format(loser.source)] = None
+        own = [flag for flag in winner.flags if not flag.startswith('also-on-')]
+        return [*own, *elsewhere]
 
     def _easy_apply(self, jobs: list[Job]) -> list[tuple[Job, str, str]]:
         client = self.linkedin()

--- a/src/applicant/search.py
+++ b/src/applicant/search.py
@@ -92,24 +92,26 @@ class Jobs:
         keywords: str,
         filters: JobFilter | None = None,
         limit: int = 25,
+        want: int | None = None,
+        max_rounds: int = 4,
         on_error: Callable[[str, Exception], None] | None = None,
     ) -> list[Job]:
         """Search every configured board and return the filtered, merged results.
 
         `limit` is per board *before* filtering, so a strict filter returns fewer.
+        `want` asks for a number of *survivors* instead: each board is re-read
+        with a larger limit until that many get through, the board runs out, or
+        `max_rounds` is reached. Left as None nothing changes and each board is
+        read exactly once.
         """
         filters = filters or JobFilter()
         collected: list[Job] = []
 
         for name in self.sources:
             client = self._client(name)
-            native = client.capability.filters
             try:
-                jobs = client.search(
-                    keywords,
-                    filters.location or '',
-                    limit=limit,
-                    posted_within_days=(filters.posted_within_days if 'posted' in native else None),
+                kept, seen = self._from_board(
+                    client, name, keywords, filters, limit, want, max_rounds
                 )
             except JobsError as error:
                 (on_error or self._report)(name, error)
@@ -119,9 +121,45 @@ class Jobs:
                 if name != 'linkedin':
                     client.close()
 
-            # whatever the board filtered for us, we must not filter again -
-            # see Capability.filters for why a second pass would be wrong
-            skip = sorted(native)
+            print('{}: {} of {} jobs match'.format(name, len(kept), seen))
+            collected.extend(kept)
+
+        return collected
+
+    def _from_board(
+        self,
+        client: Board,
+        name: str,
+        keywords: str,
+        filters: JobFilter,
+        limit: int,
+        want: int | None,
+        max_rounds: int,
+    ) -> tuple[list[Job], int]:
+        """One board's surviving jobs, and how many were read to get them.
+
+        Reading more means asking for a bigger page and re-reading what we
+        already saw: the boards page from the top, and Google Jobs only exists
+        as a scrolling list, so there is no offset to resume from. That is why
+        rounds are capped and why one round remains the default - each extra one
+        is a fresh set of requests against a site that is watching for exactly
+        that.
+        """
+        native = client.capability.filters
+        # whatever the board filtered for us, we must not filter again -
+        # see Capability.filters for why a second pass would be wrong
+        skip = sorted(native)
+        posted = filters.posted_within_days if 'posted' in native else None
+
+        pull = limit
+        kept: list[Job] = []
+        seen = 0
+
+        for round_number in range(max(1, max_rounds) if want else 1):
+            jobs = client.search(
+                keywords, filters.location or '', limit=pull, posted_within_days=posted
+            )
+            seen = len(jobs)
 
             kept = []
             for job in jobs:
@@ -131,10 +169,16 @@ class Jobs:
                 job.flags = flags
                 kept.append(job)
 
-            print('{}: {} of {} jobs match'.format(name, len(kept), len(jobs)))
-            collected.extend(kept)
+            if want is None or len(kept) >= want:
+                break
+            if seen < pull:
+                # the board gave us everything it had; asking again is pointless
+                break
+            if round_number + 1 < max_rounds:
+                pull *= 2
+                print('{}: {} of {} match, reading {}'.format(name, len(kept), seen, pull))
 
-        return collected
+        return (kept[:want] if want else kept), seen
 
     def _report(self, name: str, error: Exception) -> None:
         print('{}: {}'.format(name, error))

--- a/src/applicant/search.py
+++ b/src/applicant/search.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from collections.abc import Callable, Iterable, Sequence
 from typing import TYPE_CHECKING, Protocol
 
+from .boards import Capability
 from .filters import JobFilter
 from .models import Job, JobsError
 from .storage import ApplicationLog, save_jobs
@@ -27,6 +28,8 @@ if TYPE_CHECKING:
 
 class Board(Protocol):
     """What every board module offers, and all this facade needs of one."""
+
+    capability: Capability
 
     def search(
         self,
@@ -40,9 +43,6 @@ class Board(Protocol):
 
 
 SOURCES = ('linkedin', 'indeed', 'naukri', 'googlejobs')
-
-# boards that can filter by age server side; the rest are filtered locally
-NATIVE_DATE = ('linkedin', 'indeed')
 
 # where jobs handed to _easy_apply are staged for the LinkedIn client to read back
 EASY_APPLY_LISTING = 'applied_via_jobs_interface.json'
@@ -103,14 +103,13 @@ class Jobs:
 
         for name in self.sources:
             client = self._client(name)
+            native = client.capability.filters
             try:
                 jobs = client.search(
                     keywords,
                     filters.location or '',
                     limit=limit,
-                    posted_within_days=(
-                        filters.posted_within_days if name in NATIVE_DATE else None
-                    ),
+                    posted_within_days=(filters.posted_within_days if 'posted' in native else None),
                 )
             except JobsError as error:
                 (on_error or self._report)(name, error)
@@ -120,8 +119,9 @@ class Jobs:
                 if name != 'linkedin':
                     client.close()
 
-            # location always went to the board itself; the date did too on some
-            skip = ['location'] + (['posted'] if name in NATIVE_DATE else [])
+            # whatever the board filtered for us, we must not filter again -
+            # see Capability.filters for why a second pass would be wrong
+            skip = sorted(native)
 
             kept = []
             for job in jobs:

--- a/src/applicant/search.py
+++ b/src/applicant/search.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Protocol
 
 from .boards import Capability
 from .filters import JobFilter
+from .log import get
 from .models import Job, JobsError, experience_from
 from .storage import ApplicationLog, fingerprint, save_jobs
 
@@ -58,6 +59,8 @@ class _Enrichment:
     described: dict[tuple[str | None, str | None], str | None] = field(default_factory=dict)
     stopped: bool = False
 
+
+logger = get(__name__)
 
 # where jobs handed to _easy_apply are staged for the LinkedIn client to read back
 EASY_APPLY_LISTING = 'applied_via_jobs_interface.json'
@@ -142,7 +145,7 @@ class Jobs:
                 if name != 'linkedin':
                     client.close()
 
-            print('{}: {} of {} jobs match'.format(name, len(kept), seen))
+            logger.info('{}: {} of {} jobs match'.format(name, len(kept), seen))
             collected.extend(kept)
 
         return collected
@@ -212,7 +215,7 @@ class Jobs:
                 break
             if round_number + 1 < max_rounds:
                 pull *= 2
-                print('{}: {} of {} match, reading {}'.format(name, len(kept), seen, pull))
+                logger.info('{}: {} of {} match, reading {}'.format(name, len(kept), seen, pull))
 
         return (kept[:want] if want else kept), seen
 
@@ -240,7 +243,7 @@ class Jobs:
                     plan.described[key] = describe(job)
                 except JobsError as error:
                     # one refusal means the next request is worse than useless
-                    print('{}: {} (enrichment stopped)'.format(job.source, error))
+                    logger.warning('{}: {} (enrichment stopped)'.format(job.source, error))
                     plan.stopped = True
                     continue
                 plan.budget -= 1
@@ -270,7 +273,7 @@ class Jobs:
         return kept
 
     def _report(self, name: str, error: Exception) -> None:
-        print('{}: {}'.format(name, error))
+        logger.warning('{}: {}'.format(name, error))
 
     def apply(
         self,
@@ -318,7 +321,7 @@ class Jobs:
             entries.extend((job, 'would_apply', 'dry run') for job in linkedin_targets)
 
         written = ApplicationLog(log).record(entries)
-        print(
+        logger.info(
             '{} new rows in {} ({} already recorded)'.format(written, log, len(entries) - written)
         )
         return entries
@@ -385,7 +388,7 @@ class Jobs:
         try:
             applied = set(client.easy_apply(EASY_APPLY_LISTING))
         except JobsError as error:
-            print('linkedin: {}'.format(error))
+            logger.warning('linkedin: {}'.format(error))
             return [(job, 'failed', str(error)) for job in jobs]
 
         for job in jobs:

--- a/src/applicant/storage.py
+++ b/src/applicant/storage.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import csv
 import json
 import os
+import re
 from collections.abc import Iterable
 from datetime import datetime, timezone
 
@@ -53,6 +54,33 @@ def _key(item: dict) -> tuple:
     return item.get('source'), item.get('title'), item.get('company'), item.get('location')
 
 
+_PUNCTUATION = re.compile(r'[^a-z0-9]+')
+
+
+def _flatten(value: str | None) -> str:
+    return _PUNCTUATION.sub(' ', (value or '').lower()).strip()
+
+
+def fingerprint(item: dict) -> str | None:
+    """Identity *across* boards: one job, however many boards carried it.
+
+    `_key` is per source by design - each board's copy of a posting is worth
+    storing, since they carry different fields and only some carry a url. But
+    they are still one job, and applying to it three times is three emails to
+    the same employer.
+
+    The city alone, not the whole location string: boards write "Bengaluru",
+    "Bengaluru, Karnataka" and "Bengaluru, India" for the same office. Returns
+    None when company or title is missing, because a fingerprint that is not
+    sure is worse than none.
+    """
+    company, title = _flatten(item.get('company')), _flatten(item.get('title'))
+    if not company or not title:
+        return None
+    city = _flatten((item.get('location') or '').split(',')[0])
+    return '|'.join((company, title, city))
+
+
 def load_jobs(filepath: str) -> list[Job]:
     """Read a job listing file. Missing or malformed reads as empty."""
     try:
@@ -93,23 +121,36 @@ class ApplicationLog:
         self.path = path
 
     def existing_keys(self) -> set[tuple[str | None, str | None]]:
-        keys = set()
-        if not os.path.exists(self.path):
-            return keys
-        with open(self.path, encoding='utf-8-sig', newline='') as handle:
-            for row in csv.DictReader(handle):
-                keys.add((row.get('source'), row.get('id')))
-        return keys
+        return {(row.get('source'), row.get('id')) for row in self.rows()}
+
+    def existing_fingerprints(self) -> set[str]:
+        """What has been applied to already, whichever board it came from."""
+        found = (fingerprint(row) for row in self.rows())
+        return {value for value in found if value}
 
     def record(self, entries: Iterable[tuple[Job, str, str]]) -> int:
         """entries: iterable of (job, status, note). Returns rows written."""
-        seen = self.existing_keys()
+        rows = self.rows()
+        seen = {(row.get('source'), row.get('id')) for row in rows}
+        boards_of: dict[str, set[str | None]] = {}
+        for row in rows:
+            mark = fingerprint(row)
+            if mark:
+                boards_of.setdefault(mark, set()).add(row.get('source'))
         fresh = []
 
         for job, status, note in entries:
             if (job.source, job.id) in seen:
                 continue
+            # The same posting under another board's id is still one job. Two ids
+            # on the *same* board are not: there the id is authoritative, and
+            # collapsing them would throw away a posting the board thinks is real.
+            mark = fingerprint(job.to_dict())
+            if mark and boards_of.get(mark, set()) - {job.source}:
+                continue
             seen.add((job.source, job.id))
+            if mark:
+                boards_of.setdefault(mark, set()).add(job.source)
             salary = parse_salary(job.salary)
             fresh.append(
                 {

--- a/tests/test_boards.py
+++ b/tests/test_boards.py
@@ -53,6 +53,19 @@ class IndeedHostTest(unittest.TestCase):
         # 'Indiana' must not resolve to the Indian site
         self.assertEqual(host_for('Indianapolis, Indiana'), 'https://www.indeed.com')
 
+    def test_a_bare_city_reaches_its_own_country_site(self):
+        """'-l Bengaluru' is the spelling every other board wants.
+
+        Without this it fell through to the US site, so the one location string
+        that satisfies Naukri and the local filter answered with American jobs.
+        """
+        for location in ('Bengaluru', 'Hyderabad, Telangana', 'Pune'):
+            with self.subTest(location=location):
+                self.assertEqual(host_for(location), 'https://in.indeed.com')
+
+    def test_a_city_we_cannot_place_still_falls_back(self):
+        self.assertEqual(host_for('Springfield'), 'https://www.indeed.com')
+
 
 class IndeedUrlTest(unittest.TestCase):
     def setUp(self):

--- a/tests/test_boards.py
+++ b/tests/test_boards.py
@@ -13,11 +13,13 @@ from typing import ClassVar
 
 import httpx
 
+from applicant.boards import CAPABILITIES, capability
 from applicant.boards.googlejobs import GoogleJobs
 from applicant.boards.indeed import Indeed, host_for
 from applicant.boards.linkedin import LinkedIn
 from applicant.boards.naukri import Naukri, search_url
 from applicant.models import BlockedError, Job
+from applicant.search import SOURCES
 
 
 def mosaic_html(results: list[dict]) -> str:
@@ -421,6 +423,52 @@ class JobValidationTest(unittest.TestCase):
     def test_from_dict_ignores_fields_we_no_longer_know(self):
         job = Job.from_dict({'source': 'indeed', 'title': 'Dev', 'retired_field': 'x'})
         self.assertEqual(job.title, 'Dev')
+
+
+class CapabilityTest(unittest.TestCase):
+    """What each board declares it does, and what the declaration is used for."""
+
+    def test_every_source_declares_one(self):
+        self.assertEqual(set(CAPABILITIES), set(SOURCES))
+
+    def test_each_client_carries_its_own(self):
+        for client, name in (
+            (LinkedIn(), 'linkedin'),
+            (Indeed(), 'indeed'),
+            (Naukri(), 'naukri'),
+            (GoogleJobs(), 'googlejobs'),
+        ):
+            with self.subTest(board=name):
+                self.assertIs(client.capability, CAPABILITIES[name])
+
+    def test_every_board_filters_location_itself(self):
+        """Which is why `Jobs.search` never re-checks it locally."""
+        for name, declared in CAPABILITIES.items():
+            with self.subTest(board=name):
+                self.assertIn('location', declared.filters)
+
+    def test_only_linkedin_and_indeed_filter_by_date(self):
+        native = {name for name, cap in CAPABILITIES.items() if 'posted' in cap.filters}
+        self.assertEqual(native, {'linkedin', 'indeed'})
+
+    def test_naukri_is_the_only_board_publishing_experience(self):
+        publishes = {name for name, cap in CAPABILITIES.items() if 'experience' in cap.publishes}
+        self.assertEqual(publishes, {'naukri'})
+
+    def test_linkedin_guest_cards_publish_no_pay(self):
+        self.assertNotIn('salary', CAPABILITIES['linkedin'].publishes)
+
+    def test_google_jobs_publishes_no_url(self):
+        """Its applications route back to the originating board, reported as `via`."""
+        self.assertNotIn('url', CAPABILITIES['googlejobs'].publishes)
+        self.assertIn('via', CAPABILITIES['googlejobs'].publishes)
+
+    def test_an_unknown_source_is_assumed_to_publish_everything(self):
+        """So a board we have no entry for behaves as everything did before."""
+        assumed = capability('a-board-we-do-not-have')
+        self.assertEqual(assumed.filters, frozenset())
+        for wanted in ('experience', 'salary', 'posted'):
+            self.assertIn(wanted, assumed.publishes)
 
 
 if __name__ == '__main__':

--- a/tests/test_boards.py
+++ b/tests/test_boards.py
@@ -18,7 +18,7 @@ from applicant.boards.googlejobs import GoogleJobs
 from applicant.boards.indeed import Indeed, host_for
 from applicant.boards.linkedin import LinkedIn
 from applicant.boards.naukri import Naukri, search_url
-from applicant.models import BlockedError, Job
+from applicant.models import BlockedError, Job, experience_from
 from applicant.search import SOURCES
 
 
@@ -404,6 +404,85 @@ class LinkedInGuestSearchTest(unittest.TestCase):
 
         self.client(handler).search('python', limit=5, posted_within_days=7)
         self.assertEqual(seen[0]['f_TPR'], 'r604800')
+
+
+class LinkedInDescribeTest(unittest.TestCase):
+    """Reading a posting itself, for what its search card never carried."""
+
+    PAGE = (
+        '<section class="description"><p>You will own our models.</p>'
+        '<ul><li>3+ years of experience with Python &amp; PyTorch</li></ul></section>'
+    )
+
+    def client(self, handler) -> LinkedIn:
+        instance = LinkedIn(delay=0, client=httpx.Client(transport=httpx.MockTransport(handler)))
+        self.addCleanup(instance.close)
+        return instance
+
+    def job(self, job_id: str | None = '3812345678') -> Job:
+        return Job(source='linkedin', id=job_id, title='AI Engineer')
+
+    def test_it_reads_the_guest_posting_page(self):
+        seen = []
+
+        def handler(request):
+            seen.append(str(request.url))
+            return httpx.Response(200, text=self.PAGE)
+
+        text = self.client(handler).describe(self.job())
+        self.assertIn('/jobs-guest/jobs/api/jobPosting/3812345678', seen[0])
+        assert text is not None
+        self.assertIn('3+ years of experience', text)
+
+    def test_markup_is_reduced_to_readable_text(self):
+        text = self.client(lambda request: httpx.Response(200, text=self.PAGE)).describe(self.job())
+        assert text is not None
+        self.assertNotIn('<', text)
+        self.assertIn('Python & PyTorch', text, 'entities decoded')
+        self.assertNotIn('  ', text, 'whitespace collapsed')
+
+    def test_a_posting_with_no_id_is_not_fetched(self):
+        def handler(request):  # pragma: no cover - reaching this is the failure
+            raise AssertionError('should not have been fetched')
+
+        self.assertIsNone(self.client(handler).describe(self.job(None)))
+
+    def test_a_page_that_is_not_there_reads_as_nothing(self):
+        client = self.client(lambda request: httpx.Response(404))
+        self.assertIsNone(client.describe(self.job()))
+
+    def test_rate_limiting_is_reported_not_swallowed(self):
+        """Carrying on through a 429 is how a working scrape becomes a blocked one."""
+        client = self.client(lambda request: httpx.Response(429))
+        with self.assertRaises(BlockedError):
+            client.describe(self.job())
+
+
+class ExperienceFromTest(unittest.TestCase):
+    """What a free text description says, and the phrase it said it in."""
+
+    def test_a_stated_minimum(self):
+        self.assertEqual(
+            experience_from('We want someone with 3+ years of experience in ML.'),
+            ('3+ years', 3.0, None),
+        )
+
+    def test_a_stated_range(self):
+        found = experience_from('Requires 2-5 years of experience building systems.')
+        self.assertEqual(found, ('2-5 years', 2.0, 5.0))
+
+    def test_a_fresher_posting(self):
+        found = experience_from('An entry-level role, no experience needed.')
+        assert found is not None
+        self.assertEqual(found[1:], (0.0, 0.0))
+
+    def test_prose_that_states_nothing(self):
+        self.assertIsNone(experience_from('We are a fast growing team of engineers.'))
+        self.assertIsNone(experience_from(None))
+
+    def test_an_absurd_number_is_read_as_nothing(self):
+        """A posting saying "100 years" is a typo, not a requirement."""
+        self.assertIsNone(experience_from('Looking for 100 years of experience'))
 
 
 class JobValidationTest(unittest.TestCase):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -128,7 +128,7 @@ class StatusCommandTest(unittest.TestCase):
     def run_status(self, *extra: str) -> tuple[int, str]:
         buffer = io.StringIO()
         with redirect_stdout(buffer):
-            code = main(['status', '-i', self.listing, '--log', self.log, *extra])
+            code = main(['status', '-i', self.listing, '--log', self.log, '--no-log-file', *extra])
         return code, buffer.getvalue()
 
     def test_empty_state_reports_zeroes_rather_than_failing(self):
@@ -179,7 +179,7 @@ class RatesCommandTest(unittest.TestCase):
     def run_rates(self, *extra: str) -> tuple[int, str]:
         buffer = io.StringIO()
         with redirect_stdout(buffer):
-            code = main(['rates', *extra])
+            code = main(['rates', '--no-log-file', *extra])
         return code, buffer.getvalue()
 
     def test_it_lists_every_mapped_currency(self):
@@ -210,7 +210,7 @@ class ApplyCommandTest(unittest.TestCase):
     def test_a_missing_listing_fails_cleanly(self):
         buffer = io.StringIO()
         with redirect_stdout(buffer):
-            code = main(['apply', '-i', str(self.root / 'nope.json')])
+            code = main(['apply', '-i', str(self.root / 'nope.json'), '--no-log-file'])
 
         self.assertEqual(code, 1)
         self.assertIn('no jobs to apply to', buffer.getvalue())
@@ -221,7 +221,7 @@ class ApplyCommandTest(unittest.TestCase):
 
         buffer = io.StringIO()
         with redirect_stdout(buffer):
-            code = main(['apply', '-i', listing, '--title', 'python'])
+            code = main(['apply', '-i', listing, '--title', 'python', '--no-log-file'])
 
         self.assertEqual(code, 1)
         self.assertIn('0 of 1 stored jobs match', buffer.getvalue())
@@ -243,7 +243,19 @@ class ApplyCommandTest(unittest.TestCase):
         )
 
         with redirect_stdout(io.StringIO()):
-            code = main(['apply', '-i', listing, '--log', log, '--dry-run', '--title', 'python'])
+            code = main(
+                [
+                    'apply',
+                    '-i',
+                    listing,
+                    '--log',
+                    log,
+                    '--dry-run',
+                    '--title',
+                    'python',
+                    '--no-log-file',
+                ]
+            )
 
         self.assertEqual(code, 0)
         rows = ApplicationLog(log).rows()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -82,7 +82,7 @@ class ParserTest(unittest.TestCase):
                         '--strict',
                     ]
                 )
-                self.assertEqual(args.title, 'senior')
+                self.assertEqual(args.title, ['senior'], '--title collects, so it can repeat')
                 self.assertEqual(args.min_salary, 1_200_000)
                 self.assertEqual(args.posted_within, 7)
                 self.assertTrue(args.strict)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -51,12 +51,14 @@ class SkipTest(unittest.TestCase):
     """The board already filtered these; re-checking locally throws away good results."""
 
     def test_location_is_not_rechecked_when_skipped(self):
-        # a country search answers with bare city names, which would never match 'India'
+        # a country search answers with bare city names. 'India' now recognises
+        # its own cities (see applicant.places), so the vehicle here is a
+        # country whose cities we cannot enumerate
         posting = job(location='Bengaluru')
-        keep, _ = JobFilter(location='India').matches(posting)
+        keep, _ = JobFilter(location='Ireland').matches(posting)
         self.assertFalse(keep, 'sanity: a local check does reject this')
 
-        keep, _ = JobFilter(location='India').matches(posting, skip=['location'])
+        keep, _ = JobFilter(location='Ireland').matches(posting, skip=['location'])
         self.assertTrue(keep, 'the board already applied the location filter')
 
     def test_posted_is_not_rechecked_when_skipped(self):

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,0 +1,169 @@
+"""The running commentary: where it goes, how much of it, and when it is silent.
+
+Logging is process wide state, so every test here puts it back afterwards -
+otherwise a configured handler outlives its test and writes into a buffer
+nobody is reading any more.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import tempfile
+import unittest
+from pathlib import Path
+
+from applicant import log
+
+
+class LogTest(unittest.TestCase):
+    def setUp(self):
+        log.silence()
+        self.addCleanup(log.silence)
+        self.stream = io.StringIO()
+
+    def lines(self) -> list[str]:
+        return [line for line in self.stream.getvalue().splitlines() if line.strip()]
+
+
+class NamingTest(LogTest):
+    def test_a_module_gets_its_own_logger_under_the_package(self):
+        self.assertEqual(log.get('applicant.search').name, 'applicant.search')
+
+    def test_a_bare_name_is_placed_under_the_package(self):
+        self.assertEqual(log.get('boards.naukri').name, 'applicant.boards.naukri')
+
+    def test_the_package_name_itself_is_left_alone(self):
+        self.assertEqual(log.get('applicant').name, 'applicant')
+
+    def test_a_name_that_merely_starts_the_same_is_not_mistaken_for_ours(self):
+        self.assertEqual(log.get('applicants_helper').name, 'applicant.applicants_helper')
+
+
+class LevelTest(LogTest):
+    def test_the_three_settings(self):
+        self.assertEqual(log.level_for(log.QUIET), logging.WARNING)
+        self.assertEqual(log.level_for(log.NORMAL), logging.INFO)
+        self.assertEqual(log.level_for(1), logging.DEBUG)
+
+    def test_quieter_than_quiet_is_still_quiet(self):
+        self.assertEqual(log.level_for(-5), logging.WARNING)
+
+
+class ConsoleTest(LogTest):
+    def test_a_normal_run_reads_as_it_always_did(self):
+        """These lines were `print` calls; -v is where the decoration starts."""
+        log.configure(stream=self.stream)
+        log.get('applicant.search').info('naukri: 8 of 11 jobs match')
+        self.assertEqual(self.lines(), ['naukri: 8 of 11 jobs match'])
+
+    def test_quiet_keeps_the_failures_and_drops_the_commentary(self):
+        log.configure(log.QUIET, stream=self.stream)
+        logger = log.get('applicant.search')
+        logger.info('naukri: 8 of 11 jobs match')
+        logger.warning('naukri: served a bot check')
+        self.assertEqual(self.lines(), ['naukri: served a bot check'])
+
+    def test_verbose_says_where_each_line_came_from(self):
+        log.configure(1, stream=self.stream)
+        log.get('applicant.boards.naukri').debug('intercepted the search api call')
+
+        line = self.lines()[0]
+        self.assertIn('applicant.boards.naukri', line)
+        self.assertIn('DEBUG', line)
+        self.assertIn('intercepted the search api call', line)
+
+    def test_debug_is_not_shown_at_the_usual_level(self):
+        log.configure(stream=self.stream)
+        log.get('applicant.search').debug('every url in full')
+        self.assertEqual(self.lines(), [])
+
+    def test_configuring_twice_does_not_double_every_line(self):
+        """`main()` is called dozens of times in one test run."""
+        log.configure(stream=self.stream)
+        log.configure(stream=self.stream)
+        log.get('applicant.search').info('once')
+        self.assertEqual(self.lines(), ['once'])
+
+    def test_reconfiguring_moves_the_output(self):
+        log.configure(stream=self.stream)
+        second = io.StringIO()
+        log.configure(stream=second)
+
+        log.get('applicant.search').info('to the new one')
+        self.assertEqual(self.stream.getvalue(), '')
+        self.assertIn('to the new one', second.getvalue())
+
+
+class QuietByDefaultTest(LogTest):
+    """A library says nothing until its caller asks it to."""
+
+    def test_nothing_is_configured_until_configure_is_called(self):
+        handlers = logging.getLogger(log.ROOT).handlers
+        self.assertTrue(all(isinstance(one, logging.NullHandler) for one in handlers))
+
+    def test_silence_undoes_configure(self):
+        log.configure(stream=self.stream)
+        log.silence()
+        log.get('applicant.search').warning('into the void')
+        self.assertEqual(self.stream.getvalue(), '')
+
+    def test_the_null_handler_survives_silence(self):
+        """Without it, logging complains on stderr about having nowhere to go."""
+        log.configure(stream=self.stream)
+        log.silence()
+        handlers = logging.getLogger(log.ROOT).handlers
+        self.assertTrue(any(isinstance(one, logging.NullHandler) for one in handlers))
+
+    def test_an_unconfigured_library_still_reaches_its_callers_logging(self):
+        """Someone who configured the root logger should hear from us."""
+        self.assertTrue(logging.getLogger(log.ROOT).propagate)
+
+    def test_configuring_stops_the_records_being_handled_twice(self):
+        """Once we print them, a root handler printing them again is noise."""
+        log.configure(stream=self.stream)
+        self.assertFalse(logging.getLogger(log.ROOT).propagate)
+
+    def test_silence_hands_the_records_back(self):
+        log.configure(stream=self.stream)
+        log.silence()
+        self.assertTrue(logging.getLogger(log.ROOT).propagate)
+
+
+class LogFileTest(LogTest):
+    def setUp(self):
+        super().setUp()
+        self._dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._dir.cleanup)
+        self.path = str(Path(self._dir.name) / 'run.log')
+
+    def written(self) -> str:
+        with open(self.path, encoding='utf-8') as handle:
+            return handle.read()
+
+    def test_it_records_what_the_console_showed(self):
+        log.configure(stream=self.stream, filepath=self.path)
+        log.get('applicant.search').info('naukri: 8 of 11 jobs match')
+        self.assertIn('naukri: 8 of 11 jobs match', self.written())
+
+    def test_it_keeps_the_detail_the_console_left_out(self):
+        """The point of a file is to hold what you did not know you would want."""
+        log.configure(log.QUIET, stream=self.stream, filepath=self.path)
+        log.get('applicant.search').debug('every url in full')
+
+        self.assertEqual(self.lines(), [], 'the console was asked to be quiet')
+        self.assertIn('every url in full', self.written())
+
+    def test_it_is_timestamped_and_attributed(self):
+        log.configure(stream=self.stream, filepath=self.path)
+        log.get('applicant.boards.indeed').info('read 25 cards')
+        self.assertIn('applicant.boards.indeed', self.written())
+        self.assertIn('INFO', self.written())
+
+    def test_a_path_that_cannot_be_opened_says_so(self):
+        with self.assertRaises(OSError):
+            log.configure(filepath=str(Path(self._dir.name) / 'no' / 'such' / 'dir' / 'run.log'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 
 import io
 import logging
+import os
 import tempfile
 import unittest
+from datetime import datetime
 from pathlib import Path
 
 from applicant import log
@@ -161,8 +163,45 @@ class LogFileTest(LogTest):
         self.assertIn('INFO', self.written())
 
     def test_a_path_that_cannot_be_opened_says_so(self):
+        """And says it now, not halfway through a scrape."""
         with self.assertRaises(OSError):
             log.configure(filepath=str(Path(self._dir.name) / 'no' / 'such' / 'dir' / 'run.log'))
+
+    def test_a_run_that_says_nothing_leaves_no_file(self):
+        """With a file written on every run, an empty one is just litter.
+
+        Note that the console's level does not come into it: a file that was
+        asked for records everything, so anything logged at all creates it.
+        """
+        log.configure(log.QUIET, stream=self.stream, filepath=self.path)
+        self.assertFalse(Path(self.path).exists())
+
+    def test_the_first_record_is_what_creates_it(self):
+        log.configure(log.QUIET, stream=self.stream, filepath=self.path)
+        log.get('applicant.search').debug('below the console, still recorded')
+        self.assertTrue(Path(self.path).exists())
+
+
+class DefaultFileTest(LogTest):
+    def test_it_is_named_for_when_the_run_started(self):
+        moment = datetime(2026, 8, 12, 14, 35, 2)
+        self.assertEqual(log.default_file(moment), 'run_20260812-143502.log')
+
+    def test_it_sorts_chronologically(self):
+        earlier = log.default_file(datetime(2026, 8, 12, 9, 0, 0))
+        later = log.default_file(datetime(2026, 8, 12, 14, 0, 0))
+        self.assertLess(earlier, later)
+
+    def test_two_runs_a_second_apart_do_not_collide(self):
+        first = log.default_file(datetime(2026, 8, 12, 14, 35, 2))
+        second = log.default_file(datetime(2026, 8, 12, 14, 35, 3))
+        self.assertNotEqual(first, second)
+
+    def test_it_is_a_bare_filename_in_the_working_directory(self):
+        """Beside job_listing.json and applied_jobs.csv, where the rest goes."""
+        name = log.default_file()
+        self.assertEqual(os.path.basename(name), name)
+        self.assertTrue(name.endswith('.log'))
 
 
 if __name__ == '__main__':

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -162,10 +162,21 @@ class LogFileTest(LogTest):
         self.assertIn('applicant.boards.indeed', self.written())
         self.assertIn('INFO', self.written())
 
-    def test_a_path_that_cannot_be_opened_says_so(self):
+    def test_a_missing_directory_is_made_rather_than_refused(self):
+        """Which is how `logs/` comes to exist without anyone creating it."""
+        target = Path(self._dir.name) / 'deep' / 'down' / 'run.log'
+        log.configure(stream=self.stream, filepath=str(target))
+        log.get('applicant.search').info('recorded')
+
+        self.assertTrue(target.exists())
+
+    def test_a_path_that_cannot_be_written_says_so(self):
         """And says it now, not halfway through a scrape."""
+        blocked = Path(self._dir.name) / 'not-a-directory'
+        blocked.write_text('a file is standing where the directory would go')
+
         with self.assertRaises(OSError):
-            log.configure(filepath=str(Path(self._dir.name) / 'no' / 'such' / 'dir' / 'run.log'))
+            log.configure(filepath=str(blocked / 'run.log'))
 
     def test_a_run_that_says_nothing_leaves_no_file(self):
         """With a file written on every run, an empty one is just litter.
@@ -185,7 +196,7 @@ class LogFileTest(LogTest):
 class DefaultFileTest(LogTest):
     def test_it_is_named_for_when_the_run_started(self):
         moment = datetime(2026, 8, 12, 14, 35, 2)
-        self.assertEqual(log.default_file(moment), 'run_20260812-143502.log')
+        self.assertEqual(log.default_file(moment), os.path.join('logs', 'run_20260812-143502.log'))
 
     def test_it_sorts_chronologically(self):
         earlier = log.default_file(datetime(2026, 8, 12, 9, 0, 0))
@@ -197,11 +208,15 @@ class DefaultFileTest(LogTest):
         second = log.default_file(datetime(2026, 8, 12, 14, 35, 3))
         self.assertNotEqual(first, second)
 
-    def test_it_is_a_bare_filename_in_the_working_directory(self):
-        """Beside job_listing.json and applied_jobs.csv, where the rest goes."""
+    def test_it_lives_in_a_directory_of_its_own(self):
+        """These accumulate, one per run, so they do not go in the cwd."""
         name = log.default_file()
-        self.assertEqual(os.path.basename(name), name)
-        self.assertTrue(name.endswith('.log'))
+        self.assertEqual(os.path.dirname(name), log.FOLDER)
+        self.assertTrue(os.path.basename(name).endswith('.log'))
+
+    def test_the_directory_can_be_named(self):
+        name = log.default_file(datetime(2026, 8, 12, 14, 35, 2), folder='elsewhere')
+        self.assertEqual(name, os.path.join('elsewhere', 'run_20260812-143502.log'))
 
 
 if __name__ == '__main__':

--- a/tests/test_places.py
+++ b/tests/test_places.py
@@ -1,0 +1,110 @@
+"""Containment, and the third answer.
+
+`within` has to say yes, no, or "cannot tell" - and the last of those is the
+whole point: a table of places nobody maintains would quietly drop correct
+results, so anything it cannot settle is handed back for the caller to flag.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from applicant.places import COUNTRIES, COUNTRY_OF_PLACE, countries_in, country_for, within
+
+
+class WithinTest(unittest.TestCase):
+    def test_a_city_is_inside_its_country(self):
+        for location in (
+            'Bengaluru',
+            'Bengaluru, Karnataka',
+            'Hyderabad, Telangana',
+            'Pune, Maharashtra',
+            'Mumbai, Maharashtra',
+            'New Delhi',
+            'Gurugram, Haryana',
+        ):
+            with self.subTest(location=location):
+                self.assertIs(within('India', location), True)
+
+    def test_the_country_spelled_out_still_matches(self):
+        self.assertIs(within('India', 'Bengaluru, India'), True)
+
+    def test_case_and_spacing_do_not_matter(self):
+        self.assertIs(within('  india  ', 'BENGALURU, KARNATAKA'), True)
+
+    def test_a_renamed_city_matches_under_either_name(self):
+        for pair in (('bangalore', 'bengaluru'), ('bombay', 'mumbai'), ('calcutta', 'kolkata')):
+            with self.subTest(pair=pair):
+                for name in pair:
+                    self.assertIs(within('India', name.title()), True)
+
+    def test_somewhere_else_is_not_inside(self):
+        for location in ('Dublin, Ireland', 'Berlin, Germany', 'Austin, US', 'Singapore'):
+            with self.subTest(location=location):
+                self.assertIs(within('India', location), False)
+
+    def test_a_place_we_do_not_know_cannot_be_settled(self):
+        for location in ('Remote', 'Anywhere', 'Springfield'):
+            with self.subTest(location=location):
+                self.assertIsNone(within('India', location))
+
+    def test_a_missing_location_is_not_a_match(self):
+        """A posting that says nowhere cannot be shown to be somewhere."""
+        self.assertIs(within('India', None), False)
+        self.assertIs(within('India', ''), False)
+
+    def test_an_empty_filter_constrains_nothing(self):
+        self.assertIs(within('', 'Bengaluru'), True)
+
+    def test_a_city_filter_behaves_as_plain_text(self):
+        self.assertIs(within('Bengaluru', 'Bengaluru, Karnataka'), True)
+        self.assertIs(within('Bengaluru', 'Hyderabad, Telangana'), False)
+
+    def test_a_city_filter_does_not_reach_for_the_table(self):
+        """We know Bengaluru is in Karnataka; we do not model state to city."""
+        self.assertIs(within('Karnataka', 'Bengaluru'), False)
+
+    def test_words_may_arrive_in_any_order(self):
+        self.assertIs(within('Karnataka Bengaluru', 'Bengaluru, Karnataka'), True)
+
+    def test_a_word_boundary_keeps_india_out_of_indiana(self):
+        self.assertIs(within('India', 'Indianapolis, Indiana'), None)
+
+
+class CountryForTest(unittest.TestCase):
+    def test_a_bare_city_resolves_to_its_country(self):
+        self.assertEqual(country_for('Bengaluru'), 'india')
+        self.assertEqual(country_for('Hyderabad, Telangana'), 'india')
+
+    def test_a_named_country_resolves_to_itself(self):
+        self.assertEqual(country_for('Dublin, Ireland'), 'ireland')
+
+    def test_an_unknown_place_resolves_to_nothing(self):
+        self.assertIsNone(country_for('Springfield'))
+        self.assertIsNone(country_for(''))
+
+    def test_an_ambiguous_location_resolves_to_nothing(self):
+        """Two countries named is not one answer, so it is not an answer."""
+        self.assertIsNone(country_for('Bengaluru, India and Dublin, Ireland'))
+
+
+class TableTest(unittest.TestCase):
+    def test_every_indian_place_maps_back_to_india(self):
+        self.assertEqual(set(COUNTRY_OF_PLACE.values()), {'india'})
+
+    def test_the_places_are_lowercase_so_lookups_land(self):
+        for place in COUNTRY_OF_PLACE:
+            with self.subTest(place=place):
+                self.assertEqual(place, place.lower())
+
+    def test_india_is_among_the_country_names(self):
+        self.assertIn('india', COUNTRIES)
+
+    def test_countries_in_reports_both_routes(self):
+        self.assertEqual(countries_in('Bengaluru, Karnataka'), {'india'})
+        self.assertEqual(countries_in('Dublin, Ireland'), {'ireland'})
+        self.assertEqual(countries_in('Nowhere'), set())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_target_job_filters.py
+++ b/tests/test_target_job_filters.py
@@ -150,18 +150,41 @@ class ExperienceRangeTest(unittest.TestCase):
         counts = {years: len(kept(JobFilter(experience=years), shortlist())) for years in range(7)}
         self.assertEqual(counts, {0: 0, 1: 1, 2: 8, 3: 8, 4: 8, 5: 4, 6: 0})
 
-    def test_a_board_that_states_no_experience_is_kept_and_flagged(self):
-        """Only Naukri publishes required experience, so the rest survive flagged."""
+    def test_a_board_that_never_publishes_experience_says_so(self):
+        """Only Naukri publishes it, so the rest survive flagged as unpublished."""
         silent = posting('linkedin', 'Google', 'AI Engineer', 'Hyderabad, Telangana', None)
+        keep, flags = JobFilter(experience=3).matches(silent)
+        self.assertTrue(keep)
+        self.assertEqual(flags, ['experience-unpublished'])
+
+    def test_a_naukri_posting_that_states_nothing_is_merely_unknown(self):
+        """Same silence, different source: this board could have told us."""
+        silent = posting('naukri', 'Google', 'AI Engineer', 'Hyderabad, Telangana', None)
         keep, flags = JobFilter(experience=3).matches(silent)
         self.assertTrue(keep)
         self.assertEqual(flags, ['experience-unknown'])
 
-    def test_strict_drops_the_boards_that_state_nothing(self):
-        silent = posting('linkedin', 'Google', 'AI Engineer', 'Hyderabad, Telangana', None)
-        keep, flags = JobFilter(experience=3, keep_unknown=False).matches(silent)
-        self.assertFalse(keep)
-        self.assertEqual(flags, ['experience-unknown'])
+    def test_strict_drops_both_kinds_of_silence(self):
+        for source in ('linkedin', 'naukri'):
+            with self.subTest(source=source):
+                silent = posting(source, 'Google', 'AI Engineer', 'Hyderabad', None)
+                keep, _ = JobFilter(experience=3, keep_unknown=False).matches(silent)
+                self.assertFalse(keep)
+
+    def test_keeping_the_unpublished_spares_the_boards_that_never_say(self):
+        """What `--strict-published` is for: tighten Naukri, keep the other three."""
+        strict = JobFilter(experience=3, keep_unknown=False, keep_unpublished=True)
+
+        keep, flags = strict.matches(posting('linkedin', 'G', 'AI Engineer', 'Pune', None))
+        self.assertTrue(keep, 'LinkedIn never publishes experience; that is not the job hiding')
+        self.assertEqual(flags, ['experience-unpublished'])
+
+        keep, _ = strict.matches(posting('naukri', 'G', 'AI Engineer', 'Pune', None))
+        self.assertFalse(keep, 'Naukri does publish it, and this posting did not')
+
+    def test_the_shortlist_is_unaffected_because_it_states_its_range(self):
+        strict = JobFilter(experience=3, keep_unknown=False, keep_unpublished=True)
+        self.assertEqual(len(kept(strict, shortlist())), len(SHORTLIST))
 
 
 class TitleFilterTest(unittest.TestCase):
@@ -398,27 +421,38 @@ class SearchCommandTest(unittest.TestCase):
         self.assertEqual(set(titles(stored)), set(titles(shortlist())))
         self.assertEqual(len(stored), len(SHORTLIST), 'no posting is stored twice')
 
-    def test_strict_would_drop_a_board_that_states_no_experience(self):
-        board = StubBoard([posting('naukri', 'Google', 'AI Engineer', 'Hyderabad', None)])
+    def run_one(self, source, *extra):
+        """One posting that states no experience, from `source`, through the CLI."""
+        board = StubBoard([posting(source, 'Google', 'AI Engineer', 'Hyderabad', None)], source)
         buffer = io.StringIO()
         with patch.object(Jobs, '_client', return_value=board), redirect_stdout(buffer):
             code = main(
-                [
-                    'search',
-                    'ai',
-                    '-s',
-                    'naukri',
-                    '-l',
-                    'India',
-                    '-e',
-                    '3',
-                    '--strict',
-                    '-o',
-                    self.output,
-                ]
+                ['search', 'ai', '-s', source, '-l', 'India', '-e', '3', *extra, '-o', self.output]
             )
+        return code, buffer.getvalue()
+
+    def test_strict_would_drop_a_board_that_states_no_experience(self):
+        code, output = self.run_one('naukri', '--strict')
         self.assertEqual(code, 1)
-        self.assertIn('nothing matched', buffer.getvalue())
+        self.assertIn('nothing matched', output)
+
+    def test_strict_also_deletes_the_boards_that_never_state_it(self):
+        """The behaviour --strict-published exists to give an alternative to."""
+        code, _ = self.run_one('linkedin', '--strict')
+        self.assertEqual(code, 1)
+
+    def test_strict_published_keeps_the_board_that_never_states_it(self):
+        code, _ = self.run_one('linkedin', '--strict-published')
+        self.assertEqual(code, 0)
+        self.assertEqual(load_jobs(self.output)[0].flags, ['experience-unpublished'])
+
+    def test_strict_published_still_drops_a_board_that_could_have_said(self):
+        code, _ = self.run_one('naukri', '--strict-published')
+        self.assertEqual(code, 1)
+
+    def test_strict_wins_when_both_are_given(self):
+        code, _ = self.run_one('linkedin', '--strict', '--strict-published')
+        self.assertEqual(code, 1)
 
 
 class ApplyCommandTest(unittest.TestCase):

--- a/tests/test_target_job_filters.py
+++ b/tests/test_target_job_filters.py
@@ -24,7 +24,7 @@ from applicant.cli import main
 from applicant.filters import JobFilter
 from applicant.models import Job
 from applicant.search import Jobs
-from applicant.storage import load_jobs, save_jobs
+from applicant.storage import ApplicationLog, fingerprint, load_jobs, save_jobs
 
 # The shortlist, written the way a board hands it over: a title, the hiring
 # company, a city with its state, and the experience string in the form each
@@ -393,6 +393,81 @@ class FacadeSearchTest(unittest.TestCase):
         for job in found:
             with self.subTest(job=job.title):
                 self.assertIn('date-unknown', job.flags)
+
+
+class CrossBoardTest(unittest.TestCase):
+    """One job on three boards is one application, not three."""
+
+    def setUp(self):
+        self._dir = TemporaryDirectory()
+        self.addCleanup(self._dir.cleanup)
+        self.log = str(Path(self._dir.name) / 'applied_jobs.csv')
+
+    def everywhere(self):
+        """The Cohere Health posting as each board would hand it over."""
+        return [
+            posting('googlejobs', 'Cohere Health', 'Machine Learning Engineer', 'Hyderabad', None),
+            posting('indeed', 'Cohere Health', 'Machine Learning Engineer', 'Hyderabad, TS', None),
+            posting(
+                'linkedin', 'Cohere Health', 'Machine Learning Engineer', 'Hyderabad, India', None
+            ),
+        ]
+
+    def apply(self, jobs, **kwargs):
+        with redirect_stdout(io.StringIO()):
+            return Jobs().apply(jobs, log=self.log, dry_run=True, **kwargs)
+
+    def test_the_same_job_fingerprints_the_same_from_every_board(self):
+        marks = {fingerprint(job.to_dict()) for job in self.everywhere()}
+        self.assertEqual(len(marks), 1, 'the city, not the whole location string')
+
+    def test_only_one_row_is_written(self):
+        self.apply(self.everywhere())
+        self.assertEqual(len(ApplicationLog(self.log).rows()), 1)
+
+    def test_the_copy_you_can_act_on_is_the_one_kept(self):
+        """Google Jobs gives no url at all, so its copy is the one to lose."""
+        row = self.apply(self.everywhere())
+        self.assertEqual(len(row), 1)
+        self.assertEqual(row[0][0].source, 'linkedin')
+        self.assertTrue(row[0][0].url)
+
+    def test_the_boards_that_lost_are_named_rather_than_forgotten(self):
+        job, _, _ = self.apply(self.everywhere())[0]
+        self.assertEqual(sorted(job.flags), ['also-on-googlejobs', 'also-on-indeed'])
+
+    def test_a_later_run_does_not_apply_again_through_another_board(self):
+        google, indeed, linked = self.everywhere()
+        self.apply([linked])
+        self.apply([google, indeed])
+        self.assertEqual(len(ApplicationLog(self.log).rows()), 1)
+
+    def test_two_postings_from_one_board_are_two_postings(self):
+        """However alike they look, the board's own id is the authority."""
+        first = posting('naukri', 'Acme', 'AI Engineer', 'Pune', '2-4 Yrs')
+        second = posting('naukri', 'Acme', 'AI Engineer', 'Pune', '2-4 Yrs')
+        second.id = 'naukri-a-different-listing'
+
+        self.apply([first, second])
+        self.assertEqual(len(ApplicationLog(self.log).rows()), 2)
+
+    def test_different_jobs_at_one_company_are_left_alone(self):
+        self.apply(
+            [
+                posting('naukri', 'Mastercard', 'AI Engineer', 'Pune', '1-5 Yrs'),
+                posting('naukri', 'Mastercard', 'Data Scientist I', 'Pune', '1-5 Yrs'),
+            ]
+        )
+        self.assertEqual(len(ApplicationLog(self.log).rows()), 2)
+
+    def test_a_posting_with_no_company_is_never_guessed_at(self):
+        anonymous = [
+            Job(source='indeed', id='a', title='AI Engineer', location='Pune'),
+            Job(source='linkedin', id='b', title='AI Engineer', location='Pune'),
+        ]
+        self.assertIsNone(fingerprint(anonymous[0].to_dict()))
+        self.apply(anonymous)
+        self.assertEqual(len(ApplicationLog(self.log).rows()), 2)
 
 
 class SearchCommandTest(unittest.TestCase):

--- a/tests/test_target_job_filters.py
+++ b/tests/test_target_job_filters.py
@@ -22,7 +22,7 @@ from unittest.mock import patch
 from applicant.boards import capability
 from applicant.cli import main
 from applicant.filters import JobFilter
-from applicant.models import Job
+from applicant.models import BlockedError, Job
 from applicant.search import Jobs
 from applicant.storage import ApplicationLog, fingerprint, load_jobs, save_jobs
 
@@ -393,6 +393,104 @@ class FacadeSearchTest(unittest.TestCase):
         for job in found:
             with self.subTest(job=job.title):
                 self.assertIn('date-unknown', job.flags)
+
+
+class DescribingBoard(StubBoard):
+    """A board whose postings can be read, the way LinkedIn's guest pages can."""
+
+    def __init__(self, jobs, name='linkedin', pages=None, fail=False):
+        super().__init__(jobs, name)
+        self.pages = pages or {}
+        self.fail = fail
+        self.read: list[str | None] = []
+
+    def describe(self, job):
+        if self.fail:
+            raise BlockedError('rate limited')
+        self.read.append(job.id)
+        return self.pages.get(job.id)
+
+
+class EnrichTest(unittest.TestCase):
+    """`--enrich`: when the card says nothing, read the posting."""
+
+    def board(self, **kwargs):
+        jobs = [
+            posting('linkedin', 'Cohere Health', 'AI Engineer', 'Pune, Maharashtra', None),
+            posting('linkedin', 'Infosys', 'AI Engineer', 'Pune, Maharashtra', None),
+        ]
+        pages = {
+            jobs[0].id: 'You will own our models. 3+ years of experience with Python required.',
+            jobs[1].id: 'A graduate trainee programme for freshers.',
+        }
+        return DescribingBoard(jobs, pages=pages, **kwargs)
+
+    def run_search(self, board, **kwargs):
+        with patch.object(Jobs, '_client', return_value=board), redirect_stdout(io.StringIO()):
+            return Jobs(sources=['linkedin']).search('ai', JobFilter(experience=3), **kwargs)
+
+    def test_without_it_nothing_is_read_and_everything_survives(self):
+        board = self.board()
+        found = self.run_search(board)
+        self.assertEqual(board.read, [])
+        self.assertEqual(len(found), 2)
+        self.assertEqual(found[0].flags, ['experience-unpublished'])
+
+    def test_the_posting_answers_what_the_card_could_not(self):
+        board = self.board()
+        found = self.run_search(board, enrich=True)
+
+        self.assertEqual(len(found), 1, 'the fresher role is now knowably wrong')
+        self.assertEqual(found[0].company, 'Cohere Health')
+        self.assertEqual(found[0].experience_min, 3.0)
+        self.assertIsNone(found[0].experience_max, '3+ years has no ceiling')
+
+    def test_it_records_where_the_number_came_from(self):
+        found = self.run_search(self.board(), enrich=True)
+        self.assertIn('experience-enriched', found[0].flags)
+        self.assertEqual(found[0].experience_text, '3+ years')
+
+    def test_a_posting_that_says_nothing_is_still_kept_and_flagged(self):
+        board = DescribingBoard(
+            [posting('linkedin', 'Acme', 'AI Engineer', 'Pune', None)],
+            pages={},  # read successfully, and it stated no requirement
+        )
+        found = self.run_search(board, enrich=True)
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0].flags, ['experience-unpublished'])
+
+    def test_a_refusal_stops_the_reading_rather_than_the_run(self):
+        board = self.board(fail=True)
+        found = self.run_search(board, enrich=True)
+        self.assertEqual(len(found), 2, 'kept, because nothing could be checked')
+        for job in found:
+            self.assertIn('experience-unpublished', job.flags)
+
+    def test_the_budget_caps_how_many_postings_are_read(self):
+        board = self.board()
+        self.run_search(board, enrich=True, enrich_limit=1)
+        self.assertEqual(len(board.read), 1)
+
+    def test_a_card_that_stated_its_range_is_never_read(self):
+        board = DescribingBoard(
+            [posting('linkedin', 'Acme', 'AI Engineer', 'Pune', '2-5 years')], pages={}
+        )
+        self.run_search(board, enrich=True)
+        self.assertEqual(board.read, [], 'nothing to enrich')
+
+    def test_a_board_that_cannot_be_read_is_simply_not(self):
+        """StubBoard has no `describe`, which is how the other three boards are."""
+        board = StubBoard([posting('naukri', 'Acme', 'AI Engineer', 'Pune', None)], 'naukri')
+        with patch.object(Jobs, '_client', return_value=board), redirect_stdout(io.StringIO()):
+            found = Jobs(sources=['naukri']).search('ai', JobFilter(experience=3), enrich=True)
+        self.assertEqual(found[0].flags, ['experience-unknown'])
+
+    def test_re_reading_a_board_does_not_pay_for_the_same_page_twice(self):
+        """`--want` reads the board again; the postings are already known."""
+        board = self.board()
+        self.run_search(board, enrich=True, limit=2, want=2, max_rounds=3)
+        self.assertEqual(len(board.read), 2, 'two postings, read once each')
+        self.assertEqual(set(board.read), {job.id for job in board.jobs})
 
 
 class WantTest(unittest.TestCase):

--- a/tests/test_target_job_filters.py
+++ b/tests/test_target_job_filters.py
@@ -1,0 +1,482 @@
+"""Can the filters actually find a specific shortlist of jobs?
+
+The shortlist is eight AI/ML postings in Indian metros asking for one to five
+years, the sort of thing someone would hand the tool and expect back. These
+tests run that shortlist - plus postings that must *not* survive - through the
+real `JobFilter`, the `Jobs` facade and the `search`/`apply` commands, and pin
+down what each flag can and cannot express.
+
+Nothing here touches the network: the boards are replaced by a stub returning
+fixed postings, and no filter under test needs a currency conversion.
+"""
+
+from __future__ import annotations
+
+import io
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from applicant.cli import main
+from applicant.filters import JobFilter
+from applicant.models import Job
+from applicant.search import Jobs
+from applicant.storage import load_jobs, save_jobs
+
+# The shortlist, written the way a board hands it over: a title, the hiring
+# company, a city with its state, and the experience string in the form each
+# board emits (Naukri's '2-5 Yrs', an en dashed '2-5 years' elsewhere).
+SHORTLIST = (
+    ('naukri', 'Amazon', 'Associate Consultant - AI/ML', 'Bengaluru, Karnataka', '2-5 Yrs'),
+    ('naukri', 'LPL Financial', 'Engineer I - AI Engineering', 'Hyderabad, Telangana', '2–4 years'),
+    ('naukri', 'Walmart Global Tech', 'Data Scientist I', 'Bengaluru, Karnataka', '2-4 Yrs'),
+    ('naukri', 'Mastercard', 'AI Engineer', 'Pune, Maharashtra', '1-5 Yrs'),
+    ('naukri', 'Google', 'Forward Deployment AI Engineer', 'Hyderabad, Telangana', '2-5 years'),
+    ('naukri', 'JPMorgan Chase & Co.', 'Associate AI Engineer', 'Mumbai, Maharashtra', '2-4 Yrs'),
+    ('naukri', 'Cohere Health', 'Machine Learning Engineer', 'Hyderabad, Telangana', '2–5 years'),
+    (
+        'naukri',
+        'Deepwatch India',
+        'ML Engineer - Cybersecurity Automation',
+        'Bengaluru, Karnataka',
+        '2-4 Yrs',
+    ),
+)
+
+# Postings the same search would drag in, and that a working filter has to shed:
+# too junior, too senior, the wrong field, and the right job in the wrong country.
+DECOYS = (
+    ('naukri', 'Infosys', 'Graduate Trainee - AI', 'Bengaluru, Karnataka', 'Fresher'),
+    ('naukri', 'Adobe', 'Principal Machine Learning Engineer', 'Bengaluru, Karnataka', '8-12 Yrs'),
+    ('naukri', 'Zoho', 'Frontend Developer', 'Chennai, Tamil Nadu', '2-4 Yrs'),
+    ('linkedin', 'Stripe', 'AI Engineer', 'Dublin, Ireland', '2-5 years'),
+)
+
+
+def posting(source, company, title, location, experience, **extra) -> Job:
+    return Job(
+        source=source,
+        id='{}-{}'.format(source, abs(hash((company, title)))),
+        company=company,
+        title=title,
+        location=location,
+        experience_text=experience,
+        url='https://{}.example/{}'.format(source, abs(hash(title))),
+        **extra,
+    )
+
+
+def shortlist() -> list[Job]:
+    return [posting(*row) for row in SHORTLIST]
+
+
+def pool() -> list[Job]:
+    """The shortlist as it would arrive: mixed in with jobs that must be dropped."""
+    return shortlist() + [posting(*row) for row in DECOYS]
+
+
+def titles(jobs) -> list[str]:
+    return [job.title for job in jobs]
+
+
+def kept(filters: JobFilter, jobs, **kwargs) -> list[Job]:
+    return [job for job in jobs if filters.matches(job, **kwargs)[0]]
+
+
+class StubBoard:
+    """A board that answers with fixed postings, so no scrape and no network.
+
+    It honours the one thing the facade delegates - location - the way the real
+    boards do: a country search comes back as bare city names.
+    """
+
+    def __init__(self, jobs, name='naukri'):
+        self.jobs = jobs
+        self.name = name
+        self.calls: list[tuple] = []
+        self.closed = False
+
+    def search(self, keywords, location='', limit=25, posted_within_days=None):
+        self.calls.append((keywords, location, limit, posted_within_days))
+        found = [job for job in self.jobs if job.source == self.name]
+        if location and location.lower() not in ('india',):
+            found = [job for job in found if location.lower() in (job.location or '').lower()]
+        elif location:
+            # 'India' is a country the board understands; the Irish posting is not in it
+            found = [job for job in found if 'ireland' not in (job.location or '').lower()]
+        return found[:limit]
+
+    def close(self):
+        self.closed = True
+
+
+class ExperienceRangeTest(unittest.TestCase):
+    """The one filter that separates this shortlist cleanly from its decoys."""
+
+    def test_every_posting_yields_the_range_it_asked_for(self):
+        expected = [(2, 5), (2, 4), (2, 4), (1, 5), (2, 5), (2, 4), (2, 5), (2, 4)]
+        for job, (low, high) in zip(shortlist(), expected, strict=True):
+            with self.subTest(job=job.title):
+                self.assertEqual((job.experience_min, job.experience_max), (low, high))
+
+    def test_an_en_dash_range_parses_like_a_hyphen(self):
+        """Boards emit both, and '2-4 years' must not read as unknown."""
+        hyphen = posting('naukri', 'X', 'AI Engineer', 'Pune, Maharashtra', '2-4 Yrs')
+        en_dash = posting('naukri', 'X', 'AI Engineer', 'Pune, Maharashtra', '2–4 years')
+        self.assertEqual(
+            (hyphen.experience_min, hyphen.experience_max),
+            (en_dash.experience_min, en_dash.experience_max),
+        )
+
+    def test_three_years_of_experience_keeps_the_whole_shortlist(self):
+        self.assertEqual(len(kept(JobFilter(experience=3), shortlist())), len(SHORTLIST))
+
+    def test_it_sheds_the_fresher_and_the_principal_role(self):
+        survivors = titles(kept(JobFilter(experience=3), pool()))
+        self.assertNotIn('Graduate Trainee - AI', survivors)
+        self.assertNotIn('Principal Machine Learning Engineer', survivors)
+
+    def test_the_edges_of_the_shortlist_are_where_it_starts_thinning(self):
+        """Documented behaviour: your years must fall *inside* the stated range.
+
+        So one year only clears the 1-5 posting, and five years is outside every
+        2-4 one. Someone with two to four years is who this shortlist is for.
+        """
+        counts = {years: len(kept(JobFilter(experience=years), shortlist())) for years in range(7)}
+        self.assertEqual(counts, {0: 0, 1: 1, 2: 8, 3: 8, 4: 8, 5: 4, 6: 0})
+
+    def test_a_board_that_states_no_experience_is_kept_and_flagged(self):
+        """Only Naukri publishes required experience, so the rest survive flagged."""
+        silent = posting('linkedin', 'Google', 'AI Engineer', 'Hyderabad, Telangana', None)
+        keep, flags = JobFilter(experience=3).matches(silent)
+        self.assertTrue(keep)
+        self.assertEqual(flags, ['experience-unknown'])
+
+    def test_strict_drops_the_boards_that_state_nothing(self):
+        silent = posting('linkedin', 'Google', 'AI Engineer', 'Hyderabad, Telangana', None)
+        keep, flags = JobFilter(experience=3, keep_unknown=False).matches(silent)
+        self.assertFalse(keep)
+        self.assertEqual(flags, ['experience-unknown'])
+
+
+class TitleFilterTest(unittest.TestCase):
+    """`--title` is one AND-of-words string, which this shortlist outgrows."""
+
+    def test_no_single_title_filter_reaches_the_whole_shortlist(self):
+        for wanted in ('ai', 'ai engineer', 'engineer', 'machine learning', 'ml', 'ai ml'):
+            with self.subTest(title=wanted):
+                self.assertLess(len(kept(JobFilter(title=wanted), shortlist())), len(SHORTLIST))
+
+    def test_engineer_is_the_best_single_pass_and_still_misses_two(self):
+        missed = set(titles(shortlist())) - set(
+            titles(kept(JobFilter(title='engineer'), shortlist()))
+        )
+        self.assertEqual(missed, {'Associate Consultant - AI/ML', 'Data Scientist I'})
+
+    def test_the_shortlist_needs_a_pass_per_title_family(self):
+        """Four runs cover it, because there is no way to say 'ai OR ml' in one."""
+        found: set[str] = set()
+        for wanted in ('ai', 'ml', 'machine learning', 'data scientist'):
+            found.update(titles(kept(JobFilter(title=wanted), shortlist())))
+        self.assertEqual(found, set(titles(shortlist())))
+
+    def test_all_the_words_must_appear_so_word_order_does_not_matter(self):
+        job = posting(
+            'naukri', 'Google', 'Forward Deployment AI Engineer', 'Hyderabad', '2-5 years'
+        )
+        self.assertTrue(JobFilter(title='engineer ai').matches(job)[0])
+        self.assertFalse(JobFilter(title='ai architect').matches(job)[0], 'architect is absent')
+
+    def test_matching_is_on_substrings_so_short_words_overreach(self):
+        """'ai' is inside 'Trainee', so a two letter filter pulls in a fresher role.
+
+        Worth knowing before reaching for `-t ai`: pair it with `-e` or use a
+        longer word.
+        """
+        trainee = posting('naukri', 'Infosys', 'Graduate Trainee - AI', 'Bengaluru', 'Fresher')
+        retail = posting('indeed', 'Reliance', 'Graduate Trainee - Retail', 'Mumbai', 'Fresher')
+        self.assertTrue(JobFilter(title='ai').matches(trainee)[0])
+        self.assertTrue(JobFilter(title='ai').matches(retail)[0], 'no AI in it at all')
+
+
+class CompanyFilterTest(unittest.TestCase):
+    def test_each_company_on_the_shortlist_is_reachable_by_name(self):
+        for job in shortlist():
+            with self.subTest(company=job.company):
+                first_word = (job.company or '').split()[0]
+                self.assertEqual(titles(kept(JobFilter(company=first_word), pool())), [job.title])
+
+    def test_a_punctuated_name_matches_without_the_punctuation(self):
+        """'JPMorgan Chase & Co.' is reachable as 'jpmorgan chase'."""
+        keep, _ = JobFilter(company='jpmorgan chase').matches(shortlist()[5])
+        self.assertTrue(keep)
+
+    def test_company_and_experience_combine(self):
+        survivors = kept(JobFilter(company='google', experience=3), pool())
+        self.assertEqual(titles(survivors), ['Forward Deployment AI Engineer'])
+
+
+class LocationFilterTest(unittest.TestCase):
+    """Cities work locally; a country only works when the board did the filtering."""
+
+    def test_a_city_selects_its_postings(self):
+        self.assertEqual(len(kept(JobFilter(location='Bengaluru'), shortlist())), 3)
+        self.assertEqual(len(kept(JobFilter(location='Hyderabad'), shortlist())), 3)
+
+    def test_a_state_works_too_because_boards_include_it(self):
+        self.assertEqual(len(kept(JobFilter(location='Karnataka'), shortlist())), 3)
+
+    def test_india_matches_nothing_locally(self):
+        """Every posting says 'Bengaluru, Karnataka'; none of them says India.
+
+        This is why `Jobs.search` hands location to the board and skips the local
+        check - see FacadeSearchTest. It also means `-l India` is wrong on the
+        `apply` command, which has no board to delegate to.
+        """
+        self.assertEqual(kept(JobFilter(location='India'), shortlist()), [])
+
+    def test_skipping_the_recheck_keeps_what_the_board_returned(self):
+        survivors = kept(JobFilter(location='India'), shortlist(), skip=['location'])
+        self.assertEqual(len(survivors), len(SHORTLIST))
+
+    def test_naming_every_city_takes_one_pass_each(self):
+        found: set[str] = set()
+        for city in ('Bengaluru', 'Hyderabad', 'Pune', 'Mumbai'):
+            found.update(titles(kept(JobFilter(location=city), shortlist())))
+        self.assertEqual(found, set(titles(shortlist())))
+
+
+class CombinedFilterTest(unittest.TestCase):
+    """The filter a real run would carry, over the shortlist plus its decoys."""
+
+    def test_a_realistic_search_returns_the_shortlist_and_nothing_else(self):
+        survivors = kept(
+            JobFilter(title='engineer', experience=3),
+            [job for job in pool() if 'ireland' not in (job.location or '').lower()],
+        )
+        self.assertEqual(
+            set(titles(survivors)),
+            {
+                'Engineer I - AI Engineering',
+                'AI Engineer',
+                'Forward Deployment AI Engineer',
+                'Associate AI Engineer',
+                'Machine Learning Engineer',
+                'ML Engineer - Cybersecurity Automation',
+            },
+            'the two non-engineer titles need their own pass',
+        )
+
+    def test_the_union_of_four_passes_is_the_shortlist_exactly(self):
+        """What it takes to get all eight and none of the decoys in one sitting."""
+        survivors: dict[str, Job] = {}
+        for wanted in ('ai', 'ml', 'machine learning', 'data scientist'):
+            for job in kept(
+                JobFilter(title=wanted, experience=3, location='India'), pool(), skip=['location']
+            ):
+                survivors[job.title] = job
+
+        self.assertEqual(set(survivors), set(titles(shortlist())))
+        self.assertNotIn('Graduate Trainee - AI', survivors, 'the fresher role is shed by -e 3')
+
+
+class FacadeSearchTest(unittest.TestCase):
+    """`Jobs.search`: location goes to the board, the rest is applied locally."""
+
+    def stub(self, **kwargs):
+        board = StubBoard(pool())
+        return board, Jobs(sources=['naukri'], **kwargs)
+
+    def run_search(self, board, jobs, filters):
+        with patch.object(Jobs, '_client', return_value=board), redirect_stdout(io.StringIO()):
+            return jobs.search('ai ml engineer', filters, limit=25)
+
+    def test_location_is_pushed_to_the_board_not_rechecked(self):
+        board, jobs = self.stub()
+        found = self.run_search(board, jobs, JobFilter(location='India', experience=3))
+
+        self.assertEqual(board.calls[0][1], 'India', 'the board was asked for India')
+        # every shortlisted posting comes back, even though not one of them says
+        # 'India' - the local recheck that would have dropped them all is skipped
+        self.assertTrue(set(titles(shortlist())) <= set(titles(found)))
+        # the decoys that location and experience *can* speak to are gone; the
+        # frontend role is not, because nothing here filters on the field
+        for gone in ('Graduate Trainee - AI', 'Principal Machine Learning Engineer'):
+            self.assertNotIn(gone, titles(found))
+        self.assertIn('Frontend Developer', titles(found), 'needs -t to shed')
+
+    def test_the_experience_filter_still_runs_locally(self):
+        board, jobs = self.stub()
+        found = self.run_search(board, jobs, JobFilter(location='India'))
+        self.assertIn('Graduate Trainee - AI', titles(found), 'no -e, so the fresher survives')
+
+        found = self.run_search(board, jobs, JobFilter(location='India', experience=3))
+        self.assertNotIn('Graduate Trainee - AI', titles(found))
+
+    def test_a_city_search_narrows_to_that_city(self):
+        board, jobs = self.stub()
+        found = self.run_search(board, jobs, JobFilter(location='Hyderabad', experience=3))
+        self.assertEqual(
+            set(titles(found)),
+            {
+                'Engineer I - AI Engineering',
+                'Forward Deployment AI Engineer',
+                'Machine Learning Engineer',
+            },
+        )
+
+    def test_the_date_filter_is_not_pushed_to_a_board_that_cannot_do_it(self):
+        """Naukri's age filter sits behind an API we cannot call, so it stays local."""
+        board, jobs = self.stub()
+        self.run_search(board, jobs, JobFilter(location='India', posted_within_days=7))
+        self.assertIsNone(board.calls[0][3])
+
+    def test_undated_postings_survive_flagged_rather_than_vanishing(self):
+        board, jobs = self.stub()
+        found = self.run_search(board, jobs, JobFilter(location='India', posted_within_days=7))
+        self.assertEqual(len(found), len(pool()) - 1, 'only the Irish posting is gone')
+        for job in found:
+            with self.subTest(job=job.title):
+                self.assertIn('date-unknown', job.flags)
+
+
+class SearchCommandTest(unittest.TestCase):
+    """The same run through `applicant search`, argv and output file included."""
+
+    def setUp(self):
+        self._dir = TemporaryDirectory()
+        self.addCleanup(self._dir.cleanup)
+        self.output = str(Path(self._dir.name) / 'job_listing.json')
+
+    def run_cli(self, *argv):
+        board = StubBoard(pool())
+        buffer = io.StringIO()
+        with patch.object(Jobs, '_client', return_value=board), redirect_stdout(buffer):
+            code = main([*argv, '-o', self.output])
+        return code, buffer.getvalue()
+
+    def test_a_full_invocation_stores_the_shortlist(self):
+        code, output = self.run_cli(
+            'search', 'ai ml engineer', '-s', 'naukri', '-l', 'India', '-e', '3'
+        )
+        self.assertEqual(code, 0)
+        # 11 postings on this board, 9 survive: the eight wanted, plus a frontend
+        # role that only a -t pass can shed
+        self.assertIn('naukri: 9 of 11 jobs match', output)
+        self.assertTrue(set(titles(shortlist())) <= set(titles(load_jobs(self.output))))
+
+    def test_the_title_flag_narrows_it_further(self):
+        code, _ = self.run_cli(
+            'search',
+            'ai ml engineer',
+            '-s',
+            'naukri',
+            '-l',
+            'India',
+            '-e',
+            '3',
+            '-t',
+            'data scientist',
+        )
+        self.assertEqual(code, 0)
+        self.assertEqual(titles(load_jobs(self.output)), ['Data Scientist I'])
+
+    def test_runs_merge_rather_than_overwrite_so_passes_accumulate(self):
+        """Four title passes into one file is how the whole shortlist is collected."""
+        for wanted in ('ai', 'ml', 'machine learning', 'data scientist'):
+            code, _ = self.run_cli(
+                'search', 'ai ml engineer', '-s', 'naukri', '-l', 'India', '-e', '3', '-t', wanted
+            )
+            self.assertEqual(code, 0)
+
+        stored = load_jobs(self.output)
+        self.assertEqual(set(titles(stored)), set(titles(shortlist())))
+        self.assertEqual(len(stored), len(SHORTLIST), 'no posting is stored twice')
+
+    def test_strict_would_drop_a_board_that_states_no_experience(self):
+        board = StubBoard([posting('naukri', 'Google', 'AI Engineer', 'Hyderabad', None)])
+        buffer = io.StringIO()
+        with patch.object(Jobs, '_client', return_value=board), redirect_stdout(buffer):
+            code = main(
+                [
+                    'search',
+                    'ai',
+                    '-s',
+                    'naukri',
+                    '-l',
+                    'India',
+                    '-e',
+                    '3',
+                    '--strict',
+                    '-o',
+                    self.output,
+                ]
+            )
+        self.assertEqual(code, 1)
+        self.assertIn('nothing matched', buffer.getvalue())
+
+
+class ApplyCommandTest(unittest.TestCase):
+    """`apply` re-filters the stored file, and has no board to delegate to."""
+
+    def setUp(self):
+        self._dir = TemporaryDirectory()
+        self.addCleanup(self._dir.cleanup)
+        root = Path(self._dir.name)
+        self.listing = str(root / 'job_listing.json')
+        self.log = str(root / 'applied_jobs.csv')
+        save_jobs(pool(), self.listing)
+
+    def run_cli(self, *filters):
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            code = main(['apply', '-i', self.listing, '--log', self.log, '--dry-run', *filters])
+        return code, buffer.getvalue()
+
+    def test_experience_selects_the_shortlist_out_of_the_stored_file(self):
+        code, output = self.run_cli('-e', '3')
+        self.assertEqual(code, 0)
+        # the eight wanted, plus the two decoys experience alone cannot judge:
+        # a frontend role and an Irish one, both asking 2-4 years
+        self.assertIn('10 of 12 stored jobs match', output)
+
+    def test_a_city_narrows_the_stored_file(self):
+        code, output = self.run_cli('-e', '3', '-l', 'Bengaluru')
+        self.assertEqual(code, 0)
+        self.assertIn('3 of 12 stored jobs match', output)
+
+    def test_location_india_matches_nothing_here(self):
+        """`search -l India` works because the board answers it. `apply` has no
+        board, so the same flag is checked against 'Bengaluru, Karnataka' and
+        matches nothing. Filter the stored file by city, not by country.
+        """
+        code, output = self.run_cli('-e', '3', '-l', 'India')
+        self.assertEqual(code, 1)
+        self.assertIn('0 of 12 stored jobs match', output)
+
+    def test_every_shortlisted_job_is_logged_for_manual_apply(self):
+        """None of the shortlist is LinkedIn, so the CSV is a worklist of urls."""
+        from applicant.storage import ApplicationLog
+
+        code, _ = self.run_cli('-e', '3', '-t', 'engineer')
+        self.assertEqual(code, 0)
+        rows = ApplicationLog(self.log).rows()
+        by_source = {row['source']: row['status'] for row in rows}
+        self.assertEqual(by_source['naukri'], 'needs_manual_apply', 'hands off to the employer')
+        self.assertEqual(by_source['linkedin'], 'would_apply', 'the Irish decoy, on a dry run')
+        self.assertIn('Machine Learning Engineer', [row['title'] for row in rows])
+
+    def test_the_flags_recorded_say_what_could_not_be_checked(self):
+        from applicant.storage import ApplicationLog
+
+        code, _ = self.run_cli('-e', '3', '-c', 'mastercard', '--min-salary', '1200000')
+        self.assertEqual(code, 0)
+        rows = ApplicationLog(self.log).rows()
+        self.assertEqual(len(rows), 1)
+        self.assertIn('salary-unknown', rows[0]['flags'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_target_job_filters.py
+++ b/tests/test_target_job_filters.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
+from applicant.boards import capability
 from applicant.cli import main
 from applicant.filters import JobFilter
 from applicant.models import Job
@@ -88,13 +89,15 @@ def kept(filters: JobFilter, jobs, **kwargs) -> list[Job]:
 class StubBoard:
     """A board that answers with fixed postings, so no scrape and no network.
 
-    It honours the one thing the facade delegates - location - the way the real
-    boards do: a country search comes back as bare city names.
+    It carries the real board's capability declaration and honours it: the one
+    thing it filters is location, the way the real boards do, and a country
+    search comes back as bare city names.
     """
 
     def __init__(self, jobs, name='naukri'):
         self.jobs = jobs
         self.name = name
+        self.capability = capability(name)
         self.calls: list[tuple] = []
         self.closed = False
 

--- a/tests/test_target_job_filters.py
+++ b/tests/test_target_job_filters.py
@@ -692,6 +692,26 @@ class SearchCommandTest(unittest.TestCase):
         self.assertIn('naukri: 8 of 11 jobs match', output)
         self.assertEqual(set(titles(load_jobs(self.output))), set(titles(shortlist())))
 
+    def test_quiet_drops_the_commentary_and_keeps_the_answer(self):
+        """The board's progress is logging; where the file went is the result."""
+        code, output = self.run_cli('search', 'ai', '-s', 'naukri', '-l', 'India', '-q')
+        self.assertEqual(code, 0)
+        self.assertNotIn('jobs match', output)
+        self.assertIn('jobs written to', output)
+
+    def test_verbose_says_which_module_spoke(self):
+        code, output = self.run_cli('search', 'ai', '-s', 'naukri', '-l', 'India', '-v')
+        self.assertEqual(code, 0)
+        self.assertIn('applicant.search', output)
+        self.assertIn('jobs match', output)
+
+    def test_a_run_can_be_recorded_to_a_file(self):
+        target = str(Path(self._dir.name) / 'run.log')
+        code, _ = self.run_cli('search', 'ai', '-s', 'naukri', '-l', 'India', '--log-file', target)
+        self.assertEqual(code, 0)
+        with open(target, encoding='utf-8') as handle:
+            self.assertIn('jobs match', handle.read())
+
     def test_runs_still_merge_rather_than_overwrite(self):
         for wanted in ('ai', 'data scientist'):
             code, _ = self.run_cli(

--- a/tests/test_target_job_filters.py
+++ b/tests/test_target_job_filters.py
@@ -395,6 +395,65 @@ class FacadeSearchTest(unittest.TestCase):
                 self.assertIn('date-unknown', job.flags)
 
 
+class WantTest(unittest.TestCase):
+    """`--want` counts survivors; `-n` counts what was pulled to find them."""
+
+    def board(self, total=40, every=4):
+        """`total` postings, of which every `every`-th is one we are looking for."""
+        jobs = [
+            posting(
+                'naukri',
+                'Acme {}'.format(index),
+                'AI Engineer' if index % every == 0 else 'Frontend Developer',
+                'Pune, Maharashtra',
+                '2-4 Yrs',
+            )
+            for index in range(total)
+        ]
+        return StubBoard(jobs)
+
+    def run_search(self, board, **kwargs):
+        with patch.object(Jobs, '_client', return_value=board), redirect_stdout(io.StringIO()):
+            return Jobs(sources=['naukri']).search('ai', JobFilter(title='ai engineer'), **kwargs)
+
+    def pulls(self, board):
+        return [call[2] for call in board.calls]
+
+    def test_without_want_a_board_is_read_exactly_once(self):
+        board = self.board()
+        found = self.run_search(board, limit=5)
+        self.assertEqual(self.pulls(board), [5])
+        self.assertEqual(len(found), 2, 'two survivors in the first five, and that is that')
+
+    def test_the_pull_doubles_until_enough_survive(self):
+        board = self.board()
+        found = self.run_search(board, limit=5, want=4)
+        self.assertEqual(self.pulls(board), [5, 10, 20])
+        self.assertEqual(len(found), 4)
+
+    def test_it_stops_as_soon_as_the_first_round_is_enough(self):
+        board = self.board()
+        found = self.run_search(board, limit=20, want=3)
+        self.assertEqual(self.pulls(board), [20])
+        self.assertEqual(len(found), 3, 'trimmed to what was asked for')
+
+    def test_it_gives_up_when_the_board_runs_out(self):
+        board = self.board(total=6)
+        found = self.run_search(board, limit=5, want=10)
+        self.assertEqual(self.pulls(board), [5, 10], 'the second read returned fewer than asked')
+        self.assertEqual(len(found), 2)
+
+    def test_max_rounds_caps_the_re_reading(self):
+        board = self.board(total=400)
+        self.run_search(board, limit=5, want=100, max_rounds=2)
+        self.assertEqual(self.pulls(board), [5, 10])
+
+    def test_one_round_is_the_same_as_not_asking(self):
+        board = self.board()
+        self.run_search(board, limit=5, want=99, max_rounds=1)
+        self.assertEqual(self.pulls(board), [5])
+
+
 class CrossBoardTest(unittest.TestCase):
     """One job on three boards is one application, not three."""
 

--- a/tests/test_target_job_filters.py
+++ b/tests/test_target_job_filters.py
@@ -201,12 +201,21 @@ class TitleFilterTest(unittest.TestCase):
         )
         self.assertEqual(missed, {'Associate Consultant - AI/ML', 'Data Scientist I'})
 
-    def test_the_shortlist_needs_a_pass_per_title_family(self):
-        """Four runs cover it, because there is no way to say 'ai OR ml' in one."""
-        found: set[str] = set()
-        for wanted in ('ai', 'ml', 'machine learning', 'data scientist'):
-            found.update(titles(kept(JobFilter(title=wanted), shortlist())))
-        self.assertEqual(found, set(titles(shortlist())))
+    def test_several_titles_match_any_of_them(self):
+        """Which is what the shortlist needs: four title families, one filter."""
+        several = JobFilter(title=['ai', 'ml', 'machine learning', 'data scientist'])
+        self.assertEqual(set(titles(kept(several, shortlist()))), set(titles(shortlist())))
+
+    def test_one_title_still_behaves_as_a_plain_string(self):
+        self.assertEqual(
+            titles(kept(JobFilter(title='data scientist'), shortlist())),
+            titles(kept(JobFilter(title=['data scientist']), shortlist())),
+        )
+
+    def test_empty_values_do_not_constrain_anything(self):
+        for wanted in ([], ['']):
+            with self.subTest(title=wanted):
+                self.assertEqual(len(kept(JobFilter(title=wanted), shortlist())), len(SHORTLIST))
 
     def test_all_the_words_must_appear_so_word_order_does_not_matter(self):
         job = posting(
@@ -308,17 +317,22 @@ class CombinedFilterTest(unittest.TestCase):
             'the two non-engineer titles need their own pass',
         )
 
-    def test_the_union_of_four_passes_is_the_shortlist_exactly(self):
-        """What it takes to get all eight and none of the decoys in one sitting."""
-        survivors: dict[str, Job] = {}
-        for wanted in ('ai', 'ml', 'machine learning', 'data scientist'):
-            for job in kept(
-                JobFilter(title=wanted, experience=3, location='India'), pool(), skip=['location']
-            ):
-                survivors[job.title] = job
+    def test_one_filter_now_returns_the_shortlist_exactly(self):
+        """All eight, none of the decoys, in a single pass over everything.
 
-        self.assertEqual(set(survivors), set(titles(shortlist())))
-        self.assertNotIn('Graduate Trainee - AI', survivors, 'the fresher role is shed by -e 3')
+        Each flag sheds what only it can: the titles drop the frontend role, the
+        years drop the fresher and the principal one, and the country drops the
+        Irish posting - which no earlier version of this filter could do locally.
+        """
+        survivors = kept(
+            JobFilter(
+                title=['ai', 'ml', 'machine learning', 'data scientist'],
+                experience=3,
+                location='India',
+            ),
+            pool(),
+        )
+        self.assertEqual(set(titles(survivors)), set(titles(shortlist())))
 
 
 class FacadeSearchTest(unittest.TestCase):
@@ -422,17 +436,40 @@ class SearchCommandTest(unittest.TestCase):
         self.assertEqual(code, 0)
         self.assertEqual(titles(load_jobs(self.output)), ['Data Scientist I'])
 
-    def test_runs_merge_rather_than_overwrite_so_passes_accumulate(self):
-        """Four title passes into one file is how the whole shortlist is collected."""
-        for wanted in ('ai', 'ml', 'machine learning', 'data scientist'):
+    def test_one_invocation_collects_the_whole_shortlist(self):
+        """The acceptance test for repeatable -t: four title families, one run."""
+        code, output = self.run_cli(
+            'search',
+            'ai ml engineer',
+            '-s',
+            'naukri',
+            '-l',
+            'India',
+            '-e',
+            '3',
+            '-t',
+            'ai',
+            '-t',
+            'ml',
+            '-t',
+            'machine learning',
+            '-t',
+            'data scientist',
+        )
+        self.assertEqual(code, 0)
+        self.assertIn('naukri: 8 of 11 jobs match', output)
+        self.assertEqual(set(titles(load_jobs(self.output))), set(titles(shortlist())))
+
+    def test_runs_still_merge_rather_than_overwrite(self):
+        for wanted in ('ai', 'data scientist'):
             code, _ = self.run_cli(
                 'search', 'ai ml engineer', '-s', 'naukri', '-l', 'India', '-e', '3', '-t', wanted
             )
             self.assertEqual(code, 0)
 
         stored = load_jobs(self.output)
-        self.assertEqual(set(titles(stored)), set(titles(shortlist())))
-        self.assertEqual(len(stored), len(SHORTLIST), 'no posting is stored twice')
+        self.assertIn('Data Scientist I', titles(stored))
+        self.assertEqual(len(stored), len(set(titles(stored))), 'no posting is stored twice')
 
     def run_one(self, source, *extra):
         """One posting that states no experience, from `source`, through the CLI."""

--- a/tests/test_target_job_filters.py
+++ b/tests/test_target_job_filters.py
@@ -733,16 +733,24 @@ class SearchCommandTest(unittest.TestCase):
         with open(target, encoding='utf-8') as handle:
             self.assertIn('jobs match', handle.read())
 
-    def test_a_run_records_itself_without_being_asked(self):
-        """The default is a run_<timestamp>.log beside the other output files."""
+    def test_a_run_records_itself_into_the_logs_directory(self):
+        """Made on the way, so nobody has to create `logs/` first."""
         here = Path(self._dir.name)
         with _in_directory(here):
             code, _ = self.run_cli('search', 'ai', '-s', 'naukri', '-l', 'India', log_file=True)
 
         self.assertEqual(code, 0)
-        written = list(here.glob('run_*.log'))
+        written = list((here / 'logs').glob('run_*.log'))
         self.assertEqual(len(written), 1)
         self.assertIn('jobs match', written[0].read_text(encoding='utf-8'))
+
+    def test_the_working_directory_gains_nothing_but_that(self):
+        """The point of the directory: one file per run does not belong loose."""
+        here = Path(self._dir.name)
+        with _in_directory(here):
+            self.run_cli('search', 'ai', '-s', 'naukri', '-l', 'India', log_file=True)
+
+        self.assertEqual(list(here.glob('*.log')), [])
 
     def test_no_log_file_leaves_the_directory_alone(self):
         here = Path(self._dir.name)
@@ -750,7 +758,7 @@ class SearchCommandTest(unittest.TestCase):
             code, _ = self.run_cli('search', 'ai', '-s', 'naukri', '-l', 'India', '--no-log-file')
 
         self.assertEqual(code, 0)
-        self.assertEqual(list(here.glob('run_*.log')), [])
+        self.assertFalse((here / 'logs').exists(), 'not even the directory')
 
     def test_runs_still_merge_rather_than_overwrite(self):
         for wanted in ('ai', 'data scientist'):

--- a/tests/test_target_job_filters.py
+++ b/tests/test_target_job_filters.py
@@ -13,8 +13,9 @@ fixed postings, and no filter under test needs a currency conversion.
 from __future__ import annotations
 
 import io
+import os
 import unittest
-from contextlib import redirect_stdout
+from contextlib import contextmanager, redirect_stdout
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
@@ -84,6 +85,17 @@ def titles(jobs) -> list[str]:
 
 def kept(filters: JobFilter, jobs, **kwargs) -> list[Job]:
     return [job for job in jobs if filters.matches(job, **kwargs)[0]]
+
+
+@contextmanager
+def _in_directory(path):
+    """Run from `path`, because a default log file lands where you invoked it."""
+    previous = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(previous)
 
 
 class StubBoard:
@@ -635,11 +647,17 @@ class SearchCommandTest(unittest.TestCase):
         self.addCleanup(self._dir.cleanup)
         self.output = str(Path(self._dir.name) / 'job_listing.json')
 
-    def run_cli(self, *argv):
+    def run_cli(self, *argv, log_file=False):
+        """`log_file=True` lets the run write its default log.
+
+        Otherwise it is suppressed, so the suite does not leave a trail of
+        run_<timestamp>.log files in whatever directory pytest was started from.
+        """
         board = StubBoard(pool())
         buffer = io.StringIO()
+        quiet = [] if log_file or '--log-file' in argv else ['--no-log-file']
         with patch.object(Jobs, '_client', return_value=board), redirect_stdout(buffer):
-            code = main([*argv, '-o', self.output])
+            code = main([*argv, '-o', self.output, *quiet])
         return code, buffer.getvalue()
 
     def test_a_full_invocation_stores_the_shortlist(self):
@@ -707,10 +725,32 @@ class SearchCommandTest(unittest.TestCase):
 
     def test_a_run_can_be_recorded_to_a_file(self):
         target = str(Path(self._dir.name) / 'run.log')
-        code, _ = self.run_cli('search', 'ai', '-s', 'naukri', '-l', 'India', '--log-file', target)
+        code, output = self.run_cli(
+            'search', 'ai', '-s', 'naukri', '-l', 'India', '--log-file', target
+        )
         self.assertEqual(code, 0)
+        self.assertIn('logging this run to', output, 'a log nobody can find is no use')
         with open(target, encoding='utf-8') as handle:
             self.assertIn('jobs match', handle.read())
+
+    def test_a_run_records_itself_without_being_asked(self):
+        """The default is a run_<timestamp>.log beside the other output files."""
+        here = Path(self._dir.name)
+        with _in_directory(here):
+            code, _ = self.run_cli('search', 'ai', '-s', 'naukri', '-l', 'India', log_file=True)
+
+        self.assertEqual(code, 0)
+        written = list(here.glob('run_*.log'))
+        self.assertEqual(len(written), 1)
+        self.assertIn('jobs match', written[0].read_text(encoding='utf-8'))
+
+    def test_no_log_file_leaves_the_directory_alone(self):
+        here = Path(self._dir.name)
+        with _in_directory(here):
+            code, _ = self.run_cli('search', 'ai', '-s', 'naukri', '-l', 'India', '--no-log-file')
+
+        self.assertEqual(code, 0)
+        self.assertEqual(list(here.glob('run_*.log')), [])
 
     def test_runs_still_merge_rather_than_overwrite(self):
         for wanted in ('ai', 'data scientist'):
@@ -729,7 +769,20 @@ class SearchCommandTest(unittest.TestCase):
         buffer = io.StringIO()
         with patch.object(Jobs, '_client', return_value=board), redirect_stdout(buffer):
             code = main(
-                ['search', 'ai', '-s', source, '-l', 'India', '-e', '3', *extra, '-o', self.output]
+                [
+                    'search',
+                    'ai',
+                    '-s',
+                    source,
+                    '-l',
+                    'India',
+                    '-e',
+                    '3',
+                    *extra,
+                    '-o',
+                    self.output,
+                    '--no-log-file',
+                ]
             )
         return code, buffer.getvalue()
 
@@ -771,7 +824,18 @@ class ApplyCommandTest(unittest.TestCase):
     def run_cli(self, *filters):
         buffer = io.StringIO()
         with redirect_stdout(buffer):
-            code = main(['apply', '-i', self.listing, '--log', self.log, '--dry-run', *filters])
+            code = main(
+                [
+                    'apply',
+                    '-i',
+                    self.listing,
+                    '--log',
+                    self.log,
+                    '--dry-run',
+                    '--no-log-file',
+                    *filters,
+                ]
+            )
         return code, buffer.getvalue()
 
     def test_experience_selects_the_shortlist_out_of_the_stored_file(self):

--- a/tests/test_target_job_filters.py
+++ b/tests/test_target_job_filters.py
@@ -254,14 +254,27 @@ class LocationFilterTest(unittest.TestCase):
     def test_a_state_works_too_because_boards_include_it(self):
         self.assertEqual(len(kept(JobFilter(location='Karnataka'), shortlist())), 3)
 
-    def test_india_matches_nothing_locally(self):
-        """Every posting says 'Bengaluru, Karnataka'; none of them says India.
+    def test_india_recognises_its_own_cities(self):
+        """Not one posting says 'India'; all eight are in it all the same."""
+        self.assertEqual(len(kept(JobFilter(location='India'), shortlist())), len(SHORTLIST))
 
-        This is why `Jobs.search` hands location to the board and skips the local
-        check - see FacadeSearchTest. It also means `-l India` is wrong on the
-        `apply` command, which has no board to delegate to.
-        """
-        self.assertEqual(kept(JobFilter(location='India'), shortlist()), [])
+    def test_a_posting_somewhere_else_is_still_dropped(self):
+        elsewhere = posting('linkedin', 'Stripe', 'AI Engineer', 'Dublin, Ireland', '2-5 years')
+        keep, flags = JobFilter(location='India').matches(elsewhere)
+        self.assertFalse(keep)
+        self.assertEqual(flags, [])
+
+    def test_a_place_we_cannot_resolve_is_kept_and_flagged(self):
+        """The codebase's rule for anything it cannot check: keep it, say so."""
+        vague = posting('linkedin', 'Acme', 'AI Engineer', 'Remote', '2-5 years')
+        keep, flags = JobFilter(location='India').matches(vague)
+        self.assertTrue(keep)
+        self.assertEqual(flags, ['location-unverified'])
+
+    def test_strict_drops_what_it_could_not_place(self):
+        vague = posting('linkedin', 'Acme', 'AI Engineer', 'Remote', '2-5 years')
+        keep, _ = JobFilter(location='India', keep_unknown=False).matches(vague)
+        self.assertFalse(keep)
 
     def test_skipping_the_recheck_keeps_what_the_board_returned(self):
         survivors = kept(JobFilter(location='India'), shortlist(), skip=['location'])
@@ -484,14 +497,15 @@ class ApplyCommandTest(unittest.TestCase):
         self.assertEqual(code, 0)
         self.assertIn('3 of 12 stored jobs match', output)
 
-    def test_location_india_matches_nothing_here(self):
-        """`search -l India` works because the board answers it. `apply` has no
-        board, so the same flag is checked against 'Bengaluru, Karnataka' and
-        matches nothing. Filter the stored file by city, not by country.
+    def test_location_india_narrows_the_stored_file(self):
+        """`apply` has no board to delegate to, so it resolves the country itself.
+
+        Nine survive: the eight wanted plus an Indian frontend role, with the
+        Irish posting the only one the country filter sheds.
         """
         code, output = self.run_cli('-e', '3', '-l', 'India')
-        self.assertEqual(code, 1)
-        self.assertIn('0 of 12 stored jobs match', output)
+        self.assertEqual(code, 0)
+        self.assertIn('9 of 12 stored jobs match', output)
 
     def test_every_shortlisted_job_is_logged_for_manual_apply(self):
         """None of the shortlist is LinkedIn, so the CSV is a worklist of urls."""


### PR DESCRIPTION
Started as a question - can the filters actually find a given list of jobs? - and the answer turned out to be "yes, if you run the tool four times and know which flags quietly do nothing on which board". This branch is the test suite that established that, the plan that came out of it, and the six changes that fix it.

Two commits of context (`docs/board-parity-plan.md` has the full version), then six phases, each its own commit with its own tests.

## What the tests found

The shortlist under test is eight AI/ML postings in Indian metros asking for one to five years. Against it:

| | LinkedIn | Indeed | Naukri | Google Jobs |
|---|---|---|---|---|
| filters location itself | yes | yes (+ picks the country host) | yes | yes |
| filters date itself | yes | yes | no | no |
| publishes experience | **no** | **no** | yes | **no** |
| publishes salary | no | yes | yes | heuristic |
| publishes a url | yes | yes | yes | **no** |

Experience is published by one board in four, and everything below follows from that row.

- **`--strict` deleted three of four sources.** With `-e` set, LinkedIn/Indeed/Google results are all `experience-unknown`, so a flag documented as being *more careful* discarded every non-Naukri posting.
- **`apply -l India` emptied the worklist.** Boards answer a country search with bare city names, so checking "India" against "Bengaluru, Karnataka" locally matched nothing: `0 of 12 stored jobs match`.
- **`-l Bengaluru` sent Indeed to the US site.** `host_for` looked for a country name in the location string and defaulted to `indeed.com`, so the one spelling that satisfied every other board returned American jobs.
- **No single `--title` could express the shortlist.** Best single value reached 6 of 8; the rest took four runs.
- **One job on three boards was three applications.** Identity was `(source, id)` in both the listing and the log.

## What changed

| Phase | Change |
|---|---|
| 0 | Boards declare a `Capability` - what they filter server side, what their cards publish. `Jobs.search` derives its skip list from it; `NATIVE_DATE` is gone. No behaviour change. |
| 1 | A missing field flags `-unknown` when the board publishes it and `-unpublished` when it never does. `--strict-published` drops only the first kind. |
| 2 | `places.py` resolves a country filter against cities and states, both locally and for Indeed's host. What it cannot place is kept and flagged `location-unverified`. |
| 3 | `-t` and `-c` may be repeated; a job matches when any one value does. |
| 4 | A `(company, title, city)` fingerprint collapses the same job from several boards to the copy you can act on, naming the rest as `also-on-<board>`. |
| 5 | `--want N` re-reads a board until N postings survive the filter, capped by `--max-rounds`. |
| 6 | `--enrich` reads the postings themselves to answer an `-e` filter their cards could not. |

The eight postings now come back from one invocation:

```
uv run applicant search "AI ML engineer" -l India -e 3 \
    -t ai -t ml -t "machine learning" -t "data scientist"
```

New flags: `--strict-published`, `--want`, `--max-rounds`, `--enrich`, `--enrich-limit`. `-t`/`-c` now collect.

## Worth a careful look

- **`--title` returns a list from argparse.** A single `-t` behaves as before and `JobFilter` takes a string or a sequence, but anything reading `args.title` as a string would see `['senior']`.
- **Location matching became whole-word**, because the substring test put "India" inside "Indianapolis, Indiana". Titles are deliberately unaffected and still match substrings, so `-t ml` still finds "AI/ML".
- **Applying now collapses cross-board duplicates by default.** Only across different boards - two ids on one board stay two postings, since there the board's id is the authority.
- **The place table is India-only.** That is where the tool is pointed, and an unmaintained table of the world would be worse than an honest "cannot tell".
- **`--enrich` is LinkedIn-only and experience-only.** Only LinkedIn has a posting page reachable without a browser; a salary read out of free prose is as likely to be a relocation allowance as a wage, and nothing here guesses.

## Testing

254 tests to 366, `ruff check`, `ruff format --check` and `pyright` all clean. Nothing in the suite touches the network - boards are stubbed and no filter under test needs a currency conversion.

**No part of this has been run against a live board.** The environment's proxy returns 403 for LinkedIn, so the verification is against the real code paths with board responses stubbed. The filtering logic is proven; whether the scrapers are currently unblocked is not.

Three tests I wrote failed on their first run and each caught a real defect rather than a wrong expectation: the fingerprint collapsing same-board postings, the `also-on` flags being lost when a better copy took over, and the whole-word location hole. `docs/board-parity-plan.md` records all seven places the built code deviates from the plan, including the two the plan simply got wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aUmtnQNLE7ZKtgzAVn4M4

---
_Generated by [Claude Code](https://claude.ai/code/session_018aUmtnQNLE7ZKtgzAVn4M4)_